### PR TITLE
Table desc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ mvn -Dmaven.test.skip install
 
 == Maintenance
 
-This project is maintained by Grahame Grieve and Lord Mckenzie on behalf of the FHIR community.
+This project is maintained by Grahame Grieve and Lloyd Mckenzie on behalf of the FHIR community.

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ mvn -Dmaven.test.skip install
 
 == Maintenance
 
-This project is maintained by Grahame Grieve and Llod Mckenzie on behalf of the FHIR community.
+This project is maintained by Grahame Grieve and Lord Mckenzie on behalf of the FHIR community.

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -174,6 +174,8 @@ import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.ResourceFactory;
 import org.hl7.fhir.r5.model.ResourceType;
 import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.r5.model.OperationDefinition;
+import org.hl7.fhir.r5.model.SearchParameter;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.model.StructureDefinition.StructureDefinitionContextComponent;
 import org.hl7.fhir.r5.model.StructureDefinition.StructureDefinitionKind;
@@ -4849,6 +4851,21 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     }
     if (r instanceof StructureDefinition) {
       StructureDefinition v = (StructureDefinition) r;
+      if (v.hasDescription())
+        return v.getDescriptionElement();
+    }
+    if (r instanceof OperationDefinition) {
+      OperationDefinition v = (OperationDefinition) r;
+      if (v.hasDescription())
+        return v.getDescriptionElement();
+    }
+    if (r instanceof SearchParameter) {
+      SearchParameter v = (SearchParameter) r;
+      if (v.hasDescription())
+        return v.getDescriptionElement();
+    }
+    if (r instanceof CapabilityStatement) {
+      CapabilityStatement v = (CapabilityStatement) r;
       if (v.hasDescription())
         return v.getDescriptionElement();
     }


### PR DESCRIPTION
When generating the table segments for SearchParameters, OperationDefinitions and CapabilityStatements the Description column does not extract the data from the resource (and instead uses the name)
Also, fix the spelling error on the readme page , Lloyds name isn't _Llod_