### PR TITLE
Improve rendering of tables and include an examples table as an optional output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ mvn -Dmaven.test.skip install
 
 == Maintenance
 
-This project is maintained by Grahame Grieve and Lord Mckenzie on behalf of the FHIR community.
+This project is maintained by Grahame Grieve and Lloyd Mckenzie on behalf of the FHIR community.

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ mvn -Dmaven.test.skip install
 
 == Maintenance
 
-This project is maintained by Grahame Grieve and Llod Mckenzie on behalf of the FHIR community.
+This project is maintained by Grahame Grieve and Lord Mckenzie on behalf of the FHIR community.

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FetchedFile.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FetchedFile.java
@@ -128,6 +128,7 @@ public class FetchedFile {
   }
   public FetchedResource addResource() {
     FetchedResource r = new FetchedResource();
+    r.setTitle(getTitle());
     resources.add(r);
     return r;
   }
@@ -163,6 +164,9 @@ public class FetchedFile {
   }
   public void setProcessMode(int processMode) {
     this.processMode = processMode;
+  }
+  public Boolean hasTitle() {
+    return title != null;
   }
   public String getTitle() {
     return title == null ? name : title;

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FetchedResource.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FetchedResource.java
@@ -64,8 +64,11 @@ public class FetchedResource {
     this.id = id;
     return this;
   }
+  public Boolean hasTitle() {
+    return title != null;
+  }
   public String getTitle() {
-    return title == null ? element.fhirType()+" " +id : title;
+    return title == null ? element.fhirType()+"/" + id : title;
   }
   public FetchedResource setTitle(String title) {
     this.title = title;

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -174,6 +174,8 @@ import org.hl7.fhir.r5.model.Resource;
 import org.hl7.fhir.r5.model.ResourceFactory;
 import org.hl7.fhir.r5.model.ResourceType;
 import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.r5.model.OperationDefinition;
+import org.hl7.fhir.r5.model.SearchParameter;
 import org.hl7.fhir.r5.model.StructureDefinition;
 import org.hl7.fhir.r5.model.StructureDefinition.StructureDefinitionContextComponent;
 import org.hl7.fhir.r5.model.StructureDefinition.StructureDefinitionKind;
@@ -4849,6 +4851,21 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     }
     if (r instanceof StructureDefinition) {
       StructureDefinition v = (StructureDefinition) r;
+      if (v.hasDescription())
+        return v.getDescriptionElement();
+    }
+    if (r instanceof OperationDefinition) {
+      OperationDefinition v = (OperationDefinition) r;
+      if (v.hasDescription())
+        return v.getDescriptionElement();
+    }
+    if (r instanceof SearchParameter) {
+      SearchParameter v = (SearchParameter) r;
+      if (v.hasDescription())
+        return v.getDescriptionElement();
+    }
+    if (r instanceof CapabilityStatement) {
+      CapabilityStatement v = (CapabilityStatement) r;
       if (v.hasDescription())
         return v.getDescriptionElement();
     }

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -708,6 +708,7 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
       f.println("<html><head><title>"+title+"</title></head><body><h2>"+title+"</h2>");
       f.print(tx);
       f.println("</head></html>");
+      f.close();
     }
     
   }

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -2389,6 +2389,8 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
         throw new Exception("Missing source reference on a reesource in the IG with the name "+res.getName());
       if (!bndIds.contains(res.getReference().getReference()) && !res.hasUserData("loaded.resource")) { // todo: this doesn't work for differential builds
         FetchedFile f = fetcher.fetch(res.getReference(), igf);
+        if (!f.hasTitle() && res.getName() != null)
+          f.setTitle(res.getName());
         boolean rchanged = noteFile(res, f);        
         needToBuild = rchanged || needToBuild;
         if (rchanged) 
@@ -4767,6 +4769,8 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
       else
         ref = ref+"."+prefixType;
     PrimitiveType desc = new StringType(r.getTitle());
+    if (!r.hasTitle())
+      desc = new StringType(f.getTitle());
     if (r.getResource() != null && r.getResource() instanceof MetadataResource) {
       name = ((MetadataResource) r.getResource()).present();
       desc = getDesc((MetadataResource) r.getResource(), desc);

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -5622,6 +5622,9 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
 
     if (igpkp.wantGen(r, "example-list"))
       fragment("StructureDefinition-example-list-"+sd.getId(), sdr.exampleList(fileList), f.getOutputNames(), r, vars, null);
+      if (igpkp.wantGen(r, "example-table"))
+      fragment("StructureDefinition-example-table-"+sd.getId(), sdr.exampleTable(fileList), f.getOutputNames(), r, vars, null);
+
 
     if (igpkp.wantGen(r, "csv")) {
       String path = Utilities.path(tempDir, r.getId()+".csv");

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
@@ -1184,6 +1184,30 @@ public class StructureDefinitionRenderer extends BaseRenderer {
     return b.toString();
   }
 
+  public String exampleTable(List<FetchedFile> fileList) {
+    StringBuilder b = new StringBuilder();
+    for (FetchedFile f : fileList) {
+      for (FetchedResource r : f.getResources()) {
+        for (String p : r.getProfiles()) {
+          if (sd.getUrl().equals(p)) {
+            String name = r.fhirType() + "/" + r.getId();
+            String title = r.getTitle();
+            if (Utilities.noString(title))
+              name = "example";
+            if (f.getTitle() != null && f.getTitle() != f.getName())
+              title = f.getTitle();
+            String ref = igp.getLinkFor(r);
+            b.append(" <tr>\r\n");
+            b.append("   <td><a href=\""+ref+"\">"+Utilities.escapeXml(name)+"</a></td>\r\n");
+            b.append("   <td>"+Utilities.escapeXml(title)+"</td>\r\n");
+            b.append(" </tr>\r\n");
+          }
+        }
+      }
+    }
+    return b.toString();
+  }
+
   public String span(boolean onlyConstraints, String canonical, Set<String> outputTracker) throws IOException, FHIRException {
     return new XhtmlComposer(XhtmlComposer.HTML).compose(utils.generateSpanningTable(sd, destDir, onlyConstraints, canonical, outputTracker));
   }


### PR DESCRIPTION
For many resource types there isn't a description column and these will then just default in the name of the resource again (or the Id). Instead of doing this, leverage the name that is provided by the Implementation Guide
Also:
* close the file stream when processing the transaction log output
* create a new output snippit - table format of the examples list
* the title used when a fetched resource doesn't have one was changed from `type(space)id` to a normal resource reference `type/id`