### PR TITLE
Trap isExample() NullPointerException to fix build.

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -5423,8 +5423,14 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     else if (igr.hasExampleCanonicalType())
       return true;
     else
+    try {
       return igr.getExampleBooleanType().booleanValue();
-  }
+    }
+    catch (NullPointerException ex) {
+      System.out.println("Error: For resource " + igr.getName() + " isExample() throws " + ex);
+      return false;
+    }
+}
 
 
   private boolean forHL7orFHIR() {


### PR DESCRIPTION
Trap the NullPointerException thrown by the isExample() function in order to fix the build.  There likely is a better and more permanent fix to be made, but this allows the build to complete.