### PR TITLE
Guard against crashes when canonical-based URLs are invalid

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/ValidationServices.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/ValidationServices.java
@@ -88,9 +88,11 @@ public class ValidationServices implements IValidatorResourceFetcher {
         if (u.startsWith("/"))
           u = u.substring(1);
         String[] ul = u.split("\\/");
-        InputStream s = npm.loadResource(ul[0], ul[1]);
-        if (s != null)
-          return Manager.makeParser(context, FhirFormat.JSON).parse(s);
+        if (ul.length >= 2) {
+          InputStream s = npm.loadResource(ul[0], ul[1]);
+          if (s != null)
+            return Manager.makeParser(context, FhirFormat.JSON).parse(s);
+        }
       }
     }
     String[] parts = url.split("\\/");


### PR DESCRIPTION
The processing code assumed that canonical-based URLs would have multiple parts after the canonical base.  When resources mistakenly didn't follow this pattern, the publisher would crash.  Now it checks the length of the split array before trying to index into it.  The invalid URL is then captured and logged further down the processing chain and correctly flagged as an invalid URL.

**TO TEST:**

Create or edit a profile so that the binding valueset URL points to a URL that starts w/ FHIR canonical, but is not a proper `ValueSet` defining url.  For example: `http://hl7.org/fhir/valueset-languages.html` (instead of the proper `http://hl7.org/fhir/ValueSet/languages`).  _NOTE: I've seen folks make this mistake several times before._

**BEFORE THIS CHANGE:**

When you run the IG Publisher, you get:
```
Publishing Content Failed: 1                                                     (00:14.0975)
                                                                                 (00:14.0975)
Use -? to get command line help                                                  (00:14.0975)
                                                                                 (00:14.0975)
Stack Dump (for debugging):                                                      (00:14.0975)
java.lang.ArrayIndexOutOfBoundsException: 1
	at org.hl7.fhir.igtools.publisher.ValidationServices.fetch(ValidationServices.java:91)
	at org.hl7.fhir.r5.validation.InstanceValidator.checkReference(InstanceValidator.java:1920)
	at org.hl7.fhir.r5.validation.InstanceValidator.checkChild(InstanceValidator.java:4143)
	at org.hl7.fhir.r5.validation.InstanceValidator.validateElement(InstanceValidator.java:4025)
	at org.hl7.fhir.r5.validation.InstanceValidator.checkChild(InstanceValidator.java:4153)
	at org.hl7.fhir.r5.validation.InstanceValidator.validateElement(InstanceValidator.java:4025)
	at org.hl7.fhir.r5.validation.InstanceValidator.checkChild(InstanceValidator.java:4219)
	at org.hl7.fhir.r5.validation.InstanceValidator.validateElement(InstanceValidator.java:4025)
	at org.hl7.fhir.r5.validation.InstanceValidator.checkChild(InstanceValidator.java:4153)
	at org.hl7.fhir.r5.validation.InstanceValidator.validateElement(InstanceValidator.java:4025)
	at org.hl7.fhir.r5.validation.InstanceValidator.start(InstanceValidator.java:2974)
	at org.hl7.fhir.r5.validation.InstanceValidator.validateResource(InstanceValidator.java:4618)
	at org.hl7.fhir.r5.validation.InstanceValidator.validate(InstanceValidator.java:844)
	at org.hl7.fhir.r5.validation.InstanceValidator.validate(InstanceValidator.java:804)
	at org.hl7.fhir.igtools.publisher.Publisher.validate(Publisher.java:3957)
	at org.hl7.fhir.igtools.publisher.Publisher.validate(Publisher.java:3198)
	at org.hl7.fhir.igtools.publisher.Publisher.loadConformance(Publisher.java:3178)
	at org.hl7.fhir.igtools.publisher.Publisher.createIg(Publisher.java:768)
	at org.hl7.fhir.igtools.publisher.Publisher.execute(Publisher.java:656)
	at org.hl7.fhir.igtools.publisher.Publisher.main(Publisher.java:6622)
```

**AFTER THIS CHANGE:**

The IG Publisher will not crash, and instead you'll see errors more like this:
```
No value set found at HealthcareService.extension:language.valueCodeableConcept (url = 'http://hl7.org/fhir/valueset-languages.html')
```