### PR TITLE
When pointing to a local template that inherited from a remote packag…

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/templates/TemplateManager.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/templates/TemplateManager.java
@@ -111,10 +111,15 @@ public class TemplateManager {
     boolean noScripts = true;
     JsonObject config = null;
     if (npm.hasFile("package\\$root", "config.json")) {
-      config = JsonTrackingParser.parseJson(npm.load(Utilities.path("package", "$root"), "config.json"));
+      config = JsonTrackingParser.parseJson(npm.load("package\\$root", "config.json"));
+      configs.add(config);
+      noScripts = !config.has("script") && !config.has("targets");
+    } else if (npm.hasFile("package/$root", "config.json")) {
+      config = JsonTrackingParser.parseJson(npm.load("package/$root", "config.json"));
       configs.add(config);
       noScripts = !config.has("script") && !config.has("targets");
     }  
+
     if (noScripts) {
       for (NpmPackageFolder f : npm.getFolders().values()) {
         for (String n : f.listFiles()) {


### PR DESCRIPTION
…e template where both had 'config' files from a Windows machine using Eclipse, I ran into a problem where the NPM package manager treated the folders as using the windows separator "\" but the local package used the windows separator "/".  I changed the code to check for both.  (It may be that we should be changing code somewhere else, but I'm not sure where.)