### PR TITLE
Restore rendering the supplied ValueSet.text for the cld.

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/ValueSetRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/ValueSetRenderer.java
@@ -116,8 +116,8 @@ public class ValueSetRenderer extends BaseRenderer {
   }
 
   public String cld(Set<String> outputTracker) throws EOperationOutcome, FHIRException, IOException, org.hl7.fhir.exceptions.FHIRException  {
-//    if (vs.hasText() && vs.getText().hasDiv())
-//      return new XhtmlComposer(XhtmlComposer.HTML).compose(vs.getText().getDiv());
+    if (vs.hasText() && vs.getText().hasDiv())
+      return new XhtmlComposer(XhtmlComposer.HTML).compose(vs.getText().getDiv());
     ValueSet vsc = vs.copy();
     vsc.setText(null);
     gen.generate(null, vsc, vsc, false);


### PR DESCRIPTION
This is needed for rendering large extensionally defined value sets where it isn't reasonable to enumerate the contents of the definition as is done in the default generated ValueSet rendering.  Doing this also greatly improves the IG build performance with the large extensionally defined value sets (which otherwise can become extremely slow and nearly unusable).