### PR TITLE
Fix javadoc error on command line build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
                     <verbose>false</verbose>
                     <debug>false</debug>
                     <additionalJOption>-Xdoclint:none</additionalJOption>
+		            <source>8</source>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Set source to Java 8 for the maven-javadoc-plugin to fix a javadoc error when building from the command line.