### PR TITLE
Don't blow up if a folder pointed to by the IG as a liquid folder doe…

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/IGPublisherLiquidTemplateServices.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/IGPublisherLiquidTemplateServices.java
@@ -44,7 +44,10 @@ public class IGPublisherLiquidTemplateServices implements ILiquidTemplateProvide
   }
   
   public void load(String path) throws FileNotFoundException, IOException {
-    for (File f : new File(path).listFiles()) {
+    File p = new File(path);
+    if (!p.exists())
+      return;
+    for (File f : p.listFiles()) {
       if (f.getName().endsWith(".liquid")) {
         String fn = f.getName();
         fn = fn.substring(0, fn.indexOf("."));


### PR DESCRIPTION
…sn't exist (because it might be inherited from a template and it's fine if the folder is missing).