### PR TITLE
Corrected links pointing to maturity page.  Most treated the links as…

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -5662,8 +5662,10 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
       String mm = "";
       if (r.getResource() != null && r.getResource() instanceof DomainResource) {
         String fmm = ToolingExtensions.readStringExtension((DomainResource) r.getResource(), ToolingExtensions.EXT_FMM_LEVEL);
-        if (fmm != null)
-          mm = " <a class=\"fmm\" href=\"versions.html#maturity\" title=\"Maturity Level\">"+fmm+"</a>";
+        if (fmm != null) {
+          // Use hard-coded spec link to point to current spec because DSTU2 had maturity listed on a different page
+          mm = " <a class=\"fmm\" href=\"http://hl7.org/fhir/versions.html#maturity\" title=\"Maturity Level\">"+fmm+"</a>";
+        }
       }
       listMM.append(" <li><a href=\""+ref+"\">"+Utilities.escapeXml(name)+"</a>"+mm+" "+Utilities.escapeXml(desc.asStringValue())+"</li>\r\n");
       listsMM.append(" <li><a href=\""+ref+"\">"+Utilities.escapeXml(name)+"</a>"+mm+"</li>\r\n");
@@ -6301,7 +6303,7 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
       ss = StandardsStatus.TRIAL_USE;
     if (fmm != null)
       return "<table class=\"cols\"><tbody><tr>"+
-        "<td><a href=\""+checkAppendSlash(specPath)+"versions.html#maturity\">Maturity Level</a>: "+fmm+"</td>"+
+        "<td><a href=\"http://hl7.org/fhir/versions.html#maturity\">Maturity Level</a>: "+fmm+"</td>"+
         "<td>&nbsp;<a href=\""+checkAppendSlash(specPath)+"versions.html#std-process\" title=\"Standard Status\">"+ss.toDisplay()+"</a></td>"+
         "</tr></tbody></table>";
     else

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/CodeSystemRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/CodeSystemRenderer.java
@@ -79,8 +79,10 @@ public class CodeSystemRenderer extends BaseRenderer {
       b.append(" <tr><td>"+translate("cs.summary", "OID")+":</td><td>"+CodeSystemUtilities.getOID(cs)+" ("+translate("cs.summary", "for OID based terminology systems")+")</td></tr>\r\n");
     if (cs.hasCopyright())
       b.append(" <tr><td>"+translate("cs.summary", "Copyright")+":</td><td>"+processMarkdown("copyright", cs.getCopyrightElement())+"</td></tr>\r\n");
-    if (ToolingExtensions.hasExtension(cs, ToolingExtensions.EXT_FMM_LEVEL))
-      b.append(" <tr><td><a class=\"fmm\" href=\"versions.html#maturity\" title=\"Maturity Level\">"+translate("cs.summary", "Maturity")+"</a>:</td><td>"+ToolingExtensions.readStringExtension(cs, ToolingExtensions.EXT_FMM_LEVEL)+"</td></tr>\r\n");
+    if (ToolingExtensions.hasExtension(cs, ToolingExtensions.EXT_FMM_LEVEL)) {
+      // We link to the current version of FHIR because for historical versions (e.g. DSTU2), maturity was captured in different places
+      b.append(" <tr><td><a class=\"fmm\" href=\"http://hl7.org/fhir/versions.html#maturity\" title=\"Maturity Level\">"+translate("cs.summary", "Maturity")+"</a>:</td><td>"+ToolingExtensions.readStringExtension(cs, ToolingExtensions.EXT_FMM_LEVEL)+"</td></tr>\r\n");
+    }
     if (xml || json || ttl) {
       b.append(" <tr><td>"+translate("cs.summary", "Source Resource")+":</td><td>");
       boolean first = true;

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
@@ -221,8 +221,10 @@ public class StructureDefinitionRenderer extends BaseRenderer {
           res.append(s);
         res.append("\r\n</ul>\r\n\r\n");
       }
-      if (ToolingExtensions.hasExtension(sd, ToolingExtensions.EXT_FMM_LEVEL))
-        res.append("<p><b><a class=\"fmm\" href=\"versions.html#maturity\" title=\"Maturity Level\">"+translate("cs.summary", "Maturity")+"</a></b>: "+ToolingExtensions.readStringExtension(sd, ToolingExtensions.EXT_FMM_LEVEL)+"</p>\r\n");
+      if (ToolingExtensions.hasExtension(sd, ToolingExtensions.EXT_FMM_LEVEL)) {
+        // Use hard-coded spec link to point to current spec because DSTU2 had maturity listed on a different page
+        res.append("<p><b><a class=\"fmm\" href=\"http://hl7.org/fhir/versions.html#maturity\" title=\"Maturity Level\">"+translate("cs.summary", "Maturity")+"</a></b>: "+ToolingExtensions.readStringExtension(sd, ToolingExtensions.EXT_FMM_LEVEL)+"</p>\r\n");
+      }
       
       return res.toString();
     } catch (Exception e) {

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureMapRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureMapRenderer.java
@@ -70,8 +70,10 @@ public class StructureMapRenderer extends BaseRenderer {
       b.append(" <tr><td>"+translate("sm.summary", "Publisher")+":</td><td>"+Utilities.escapeXml(gt(map.getPublisherElement()))+"</td></tr>\r\n");
     if (map.hasCopyright())
       b.append(" <tr><td>"+translate("sm.summary", "Copyright")+":</td><td>"+processMarkdown("copyright", map.getCopyrightElement())+"</td></tr>\r\n");
-    if (ToolingExtensions.hasExtension(map, ToolingExtensions.EXT_FMM_LEVEL))
-      b.append(" <tr><td><a class=\"fmm\" href=\"versions.html#maturity\" title=\"Maturity Level\">"+translate("cs.summary", "Maturity")+"</a>:</td><td>"+ToolingExtensions.readStringExtension(map, ToolingExtensions.EXT_FMM_LEVEL)+"</td></tr>\r\n");
+    if (ToolingExtensions.hasExtension(map, ToolingExtensions.EXT_FMM_LEVEL)) {
+      // Use hard-coded spec link to point to current spec because DSTU2 had maturity listed on a different page
+      b.append(" <tr><td><a class=\"fmm\" href=\"http://hl7.org/fhir/versions.html#maturity\" title=\"Maturity Level\">"+translate("cs.summary", "Maturity")+"</a>:</td><td>"+ToolingExtensions.readStringExtension(map, ToolingExtensions.EXT_FMM_LEVEL)+"</td></tr>\r\n");
+    }
     if (xml || json || ttl) {
       b.append(" <tr><td>"+translate("sm.summary", "Source Resource")+":</td><td>");
       boolean first = true;

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/ValueSetRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/ValueSetRenderer.java
@@ -89,8 +89,10 @@ public class ValueSetRenderer extends BaseRenderer {
       b.append(" <tr><td>"+translate("vs.summary", "OID")+":</td><td>"+ValueSetUtilities.getOID(vs)+" ("+translate("vs.summary", "for OID based terminology systems")+")</td></tr>\r\n");
     if (vs.hasCopyright())
       b.append(" <tr><td>"+translate("vs.summary", "Copyright")+":</td><td>"+processMarkdown("copyright", vs.getCopyrightElement())+"</td></tr>\r\n");
-    if (ToolingExtensions.hasExtension(vs, ToolingExtensions.EXT_FMM_LEVEL))
-      b.append(" <tr><td><a class=\"fmm\" href=\"versions.html#maturity\" title=\"Maturity Level\">"+translate("cs.summary", "Maturity")+"</a>:</td><td>"+ToolingExtensions.readStringExtension(vs, ToolingExtensions.EXT_FMM_LEVEL)+"</td></tr>\r\n");
+    if (ToolingExtensions.hasExtension(vs, ToolingExtensions.EXT_FMM_LEVEL)) {
+      // Use hard-coded spec link to point to current spec because DSTU2 had maturity listed on a different page
+      b.append(" <tr><td><a class=\"fmm\" href=\"http://hl7.org/fhir/versions.html#maturity\" title=\"Maturity Level\">"+translate("cs.summary", "Maturity")+"</a>:</td><td>"+ToolingExtensions.readStringExtension(vs, ToolingExtensions.EXT_FMM_LEVEL)+"</td></tr>\r\n");
+    }
     if (xml || json || ttl) {
       b.append(" <tr><td>"+translate("vs.summary", "Source Resource")+":</td><td>");
       boolean first = true;


### PR DESCRIPTION
… 'local' pointing to versions.html#maturity, but of course that page doesn't exist in most IGs.  One pointed to the page in the version of the spec the IG was associated with - however in DSTU2, the maturity table wasn't on the versions page, it was on the resources page.  Have changed all references to be hard-coded to versions.html#maturity in the 'current' version of the spec, which given that the page is normative, should be reliable.