### PR TITLE
Avoid fatal crash due to issue #236

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTLMLInspector.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTLMLInspector.java
@@ -482,7 +482,9 @@ public class HTLMLInspector {
     if (x.hasAttribute("id"))
       targets.add(x.getAttribute("id"));
     if (Utilities.existsInList(x.getName(), "h1", "h2", "h3", "h4", "h5", "h6")) {
-      targets.add(urlify(x.allText()));      
+      if (x.allText() != null) {
+        targets.add(urlify(x.allText()));
+      }
     }
     for (XhtmlNode c : x.getChildNodes())
       listTargets(c, targets);


### PR DESCRIPTION
This is just to make the code "safer" by avoiding a crash when there are headings with no text. Perhaps the rendering can avoid it altogether, or a warning message could be produced, but this should not crash the publisher.

(sorry if coding is poor)