### PR TITLE
Issue#103 - Fixed NRE in Bundle validation for entries with no fullUrl

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/ValidationServices.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/ValidationServices.java
@@ -139,7 +139,7 @@ public class ValidationServices implements IValidatorResourceFetcher {
             for (Element be : r.getElement().getChildren("entry")) {
               Element ber = be.getNamedChild("resource");
               if (ber != null) {
-                if (be.getChildValue("fullUrl").equals(url))
+                if (be.hasChild("fullUrl") && be.getChildValue("fullUrl").equals(url))
                   return ber;
               }
             }


### PR DESCRIPTION
Addresses Issue# 103 - Fixes a nullReferenceException that results from validation of a Bundle with entries that have no fullUrl.