### PR TITLE
Don't raise an error if an element is identified as an example of an …

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -5854,7 +5854,9 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     for (FetchedResource r: examples) {
       FetchedResource baseRes = getResourceForUri(r.getExampleUri());
       if (baseRes == null) {
-        errors.add(new ValidationMessage(Source.Publisher, IssueType.NOTFOUND, r.fhirType()+"/"+r.getId(), "Unable to find profile " + r.getExampleUri() + " nominated as the profile for which resource " + r.getUrlTail()+" is an example", IssueSeverity.ERROR));
+        // We only yell if the resource doesn't exist, not only if it doesn't exist in the current IG.
+        if (context.fetchResource(StructureDefinition.class, r.getExampleUri())==null)
+          errors.add(new ValidationMessage(Source.Publisher, IssueType.NOTFOUND, r.fhirType()+"/"+r.getId(), "Unable to find profile " + r.getExampleUri() + " nominated as the profile for which resource " + r.getUrlTail()+" is an example", IssueSeverity.ERROR));
       } else {
         baseRes.addStatedExample(r);
       }


### PR DESCRIPTION
…inherited profile rather than one defined in the current resource.