### PR TITLE
Fixed a bug in Extension example usage detection

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
@@ -2030,7 +2030,7 @@ public class StructureDefinitionRenderer extends CanonicalRenderer {
 
   private boolean usesExtension(Element focus) {
     for (Element child : focus.getChildren()) {
-      if (child.getName().equals("Extension") && sd.getUrl().equals(child.getChildValue("url")))
+      if (child.getName().equals("extension") && sd.getUrl().equals(child.getChildValue("url")))
         return true;
       if (usesExtension(child))
         return true;


### PR DESCRIPTION
Resolves an issue with example usages of extensions not being identified due to aa case-sensitive to the wrong casing or "Extension" that is resulting in the Structure Definition page incorrectly indicating that there are no example usages of the Extension in the IG. 

An example in published content: http://hl7.org/fhir/us/cqfmeasures/2021May/StructureDefinition-cqfm-allocation.html