### PR TITLE
Reverted unintended commits and just fixing the SDC example import issue

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -3568,8 +3568,6 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
       throw new Exception("You must specify a version for the IG "+packageId+" ("+canonical+")");
     
     NpmPackage pi = packageId == null ? null : pcm.loadPackageFromCacheOnly(packageId, igver);
-    if (pi != null)
-      npmList.add(pi);
     if (pi == null) {
       pi = resolveDependency(canonical, packageId, igver);
       if (pi == null) {
@@ -3579,6 +3577,8 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
           throw new Exception("Unknown Package "+packageId+"#"+igver);
       }
     }
+    if (pi != null)
+      npmList.add(pi);
     logDebugMessage(LogCategory.INIT, "Load "+name+" ("+canonical+") from "+packageId+"#"+igver);
 
     if (dep.hasUri() && !dep.getUri().contains("/ImplementationGuide/")) {


### PR DESCRIPTION
npm package list wasn't being updated after importing a new package - which is what happens every time on the CI build. As a result, example resolution wasn't checking against those imported packages. Moved the point of adding the package to the list post-import. (If there's a reason why the adding to the list was happening post-import, then need to find some other way of ensuring that examples are de-referenced properly by the validator.)