### PR TITLE
added Citation to metadataResourceNames

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -4629,6 +4629,7 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     res.add("CapabilityStatement2");
     res.add("StructureMap");
     res.add("ActivityDefinition");
+    res.add("Citation");
     res.add("ChargeItemDefinition");
     res.add("CompartmentDefinition");
     res.add("ConceptMap");


### PR DESCRIPTION
[Citation](https://build.fhir.org/citation.html) is a MetadataResource and hence must be added to `metadataResourceNames` in order for the IG publisher to work with that resource.