### PR TITLE
Update all fasterxml jackson versions to match the jackson-databind v…

### DIFF
--- a/org.hl7.fhir.publisher.core/pom.xml
+++ b/org.hl7.fhir.publisher.core/pom.xml
@@ -80,17 +80,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.1</version>
+            <version>2.12.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.1</version>
+            <version>2.12.6</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jaxb-annotations</artifactId>
-            <version>2.10.1</version>
+            <version>2.12.6</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>


### PR DESCRIPTION
…ersion

ISSUE: https://github.com/HL7/fhir-ig-publisher/issues/426

When the dependabot updated the com.fasterxml.jackson.core jackson-databind dependency (on 3/30, sha d2109d5acbf5aa974b0f98651c0fa53214bd3c88) , it caused an error in the jackson-core dependency, in some cases:

Translating CQL source in folder ./input/cql (01:45.0556)
Exception in thread "main" java.lang.NoClassDefFoundError: com/fasterxml/jackson/core/util/JacksonFeature
at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:655)
at com.fasterxml.jackson.databind.ObjectMapper.<init>(ObjectMapper.java:558)
at org.cqframework.cql.cql2elm.CqlTranslatorOptionsMapper.<clinit>(CqlTranslatorOptionsMapper.java:10)
at org.hl7.fhir.igtools.publisher.CqlSubSystem.getTranslatorOptions(CqlSubSystem.java:279)
at org.hl7.fhir.igtools.publisher.CqlSubSystem.translateFolder(CqlSubSystem.java:294)
at org.hl7.fhir.igtools.publisher.CqlSubSystem.execute(CqlSubSystem.java:223)
at org.hl7.fhir.igtools.publisher.Publisher.load(Publisher.java:3928)
at org.hl7.fhir.igtools.publisher.Publisher.createIg(Publisher.java:1002)
at org.hl7.fhir.igtools.publisher.Publisher.execute(Publisher.java:858)
at org.hl7.fhir.igtools.publisher.Publisher.main(Publisher.java:10049)
Caused by: java.lang.ClassNotFoundException: com.fasterxml.jackson.core.util.JacksonFeature
at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
... 10 more

The fix is to update all the other Jackson dependencies to the equivalent version.