### PR TITLE
Update skipped apache poi dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,13 +210,13 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>4.0.1</version>
+			<version>4.1.1</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml-schemas</artifactId>
-			<version>4.0.1</version>
+			<version>4.1.1</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
The Apache POI dependencies must all share the same version, or else there will be class incompatibilities at runtime, like the following:

```shell
Exception in thread "main" java.lang.IncompatibleClassChangeError: Found interface org.apache.poi.util.POILogger, but class was expected
        at org.apache.poi.openxml4j.opc.ZipPackage.saveImpl(ZipPackage.java:497)
        at org.apache.poi.openxml4j.opc.OPCPackage.save(OPCPackage.java:1489)
        at org.apache.poi.ooxml.POIXMLDocument.write(POIXMLDocument.java:242)
        at org.hl7.fhir.r5.renderers.spreadsheets.SpreadsheetGenerator.finish(SpreadsheetGenerator.java:78)
        at org.hl7.fhir.igtools.publisher.Publisher.generateOutputsStructureDefinition(Publisher.java:9459)
        at org.hl7.fhir.igtools.publisher.Publisher.generateResourceHtml(Publisher.java:8348)
        at org.hl7.fhir.igtools.publisher.Publisher.generateHtmlOutputs(Publisher.java:8223)
        at org.hl7.fhir.igtools.publisher.Publisher.generate(Publisher.java:5991)
        at org.hl7.fhir.igtools.publisher.Publisher.createIg(Publisher.java:1018)
        at org.hl7.fhir.igtools.publisher.Publisher.execute(Publisher.java:855)
        at org.hl7.fhir.igtools.publisher.Publisher.main(Publisher.java:10193)
```

The following dependencies should always be in sync with regard to version number:

```xml
                <dependency>
			<groupId>org.apache.poi</groupId>
			<artifactId>poi</artifactId>
			<version>4.1.1</version>
			<optional>true</optional>
		</dependency>
		<dependency>
			<groupId>org.apache.poi</groupId>
			<artifactId>poi-ooxml</artifactId>
			<version>4.1.1</version>
			<optional>true</optional>
		</dependency>
		<dependency>
			<groupId>org.apache.poi</groupId>
			<artifactId>poi-ooxml-schemas</artifactId>
			<version>4.1.1</version>
			<optional>true</optional>
		</dependency>
```