### PR TITLE
Add warning if file encoding isn't UTF-8

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -10099,6 +10099,9 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
   
   public static void main(String[] args) throws Exception {
     int exitCode = 0;
+
+    org.hl7.fhir.utilities.FileFormat.checkCharsetAndWarnIfNotUTF8(System.out);
+
     if (hasNamedParam(args, "-gui")) {
       runGUI();
       // Returning here ends the main thread but leaves the GUI running

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <version>1.2.5-SNAPSHOT</version> <!-- See the note above -->
 
     <properties>
-        <core_version>5.6.67</core_version>
+        <core_version>5.6.68</core_version>
         <maven.test.skip>true</maven.test.skip>
         <apache_poi_version>4.1.1</apache_poi_version>
     </properties>


### PR DESCRIPTION
This PR requires that org.hl7.fhir.core 5.6.68 is released and will fail all checks until it is.