### PR TITLE
Add logic to link TestScripts and Profiles

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FetchedResource.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FetchedResource.java
@@ -44,7 +44,7 @@ public class FetchedResource {
   private boolean validateAsResource;
   private List<String> statedProfiles = new ArrayList<String>();
   private List<String> foundProfiles = new ArrayList<String>();
-  private List<String> testProfiles = new ArrayList<String>();
+  private List<String> testArtifacts = new ArrayList<String>();
   private boolean snapshotted;
   private String exampleUri;
   private HashSet<FetchedResource> statedExamples = new HashSet<FetchedResource>();
@@ -221,16 +221,19 @@ public class FetchedResource {
     this.path = path;
   }
 
-  public void addTestProfile(String profile) {
-    testProfiles.add(profile);  
+  public void addTestArtifact(String profile) {
+    // Check for duplicate
+    if (!testArtifacts.contains(profile)) {
+      testArtifacts.add(profile);
+    }
   }
 	  
-  public List<String> getTestProfiles() {
-    return testProfiles;
+  public List<String> getTestArtifacts() {
+    return testArtifacts;
   }
 
-  public boolean hasTestProfiles() {
-    return !testProfiles.isEmpty();
+  public boolean hasTestArtifacts() {
+    return !testArtifacts.isEmpty();
   }
 
   public HashSet<FetchedResource> getFoundTestScripts() {
@@ -238,7 +241,14 @@ public class FetchedResource {
   }
 
   public void addFoundTestScript(FetchedResource r) {
-    this.foundTestScripts.add(r);
+    // Check for duplicate
+    if (!foundTestScripts.contains(r)) {
+      this.foundTestScripts.add(r);
+    }
+  }
+
+  public boolean hasFoundTestScripts() {
+    return !foundTestScripts.isEmpty();
   }
 
 }

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FetchedResource.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FetchedResource.java
@@ -44,10 +44,12 @@ public class FetchedResource {
   private boolean validateAsResource;
   private List<String> statedProfiles = new ArrayList<String>();
   private List<String> foundProfiles = new ArrayList<String>();
+  private List<String> testProfiles = new ArrayList<String>();
   private boolean snapshotted;
   private String exampleUri;
   private HashSet<FetchedResource> statedExamples = new HashSet<FetchedResource>();
   private HashSet<FetchedResource> foundExamples = new HashSet<FetchedResource>();
+  private HashSet<FetchedResource> foundTestScripts = new HashSet<FetchedResource>();
   private ImplementationGuideDefinitionResourceComponent resEntry;
   private List<ProvenanceDetails> audits = new ArrayList<>();
   private List<ValidationMessage> errors = new ArrayList<ValidationMessage>();
@@ -218,6 +220,25 @@ public class FetchedResource {
   public void setPath(String path) {
     this.path = path;
   }
-  
-  
+
+  public void addTestProfile(String profile) {
+    testProfiles.add(profile);  
+  }
+	  
+  public List<String> getTestProfiles() {
+    return testProfiles;
+  }
+
+  public boolean hasTestProfiles() {
+    return !testProfiles.isEmpty();
+  }
+
+  public HashSet<FetchedResource> getFoundTestScripts() {
+    return foundTestScripts;
+  }
+
+  public void addFoundTestScript(FetchedResource r) {
+    this.foundTestScripts.add(r);
+  }
+
 }


### PR DESCRIPTION
### What does this Pull Request do?
Add logic that links TestScript resources to Profiles (StructureDefinitions).

### Why?
The FHIR community has been increasingly interested in provided better support for testing artifacts within IGs. This additional logic is an initial enhancement that allows IGs generated from the HL7 IG template to incorporate and list TestScript resources with their associated FHIR Profiles (StructureDefinitions).

### How?
Minor code additions to two (2) classes that provide the needed links between TestScripts and StructureDefinitions:
* **FetchedResource** 
  * New List\<String\> variable **testProfiles** to hold the canonical url(s) of the FHIR Profile(s) referenced in a TestScript resource; along with corresponding getter and setter methods
  * New HashSet\<FetchedResource\> variable **foundTestScripts** to hold the linked TestScript resource(s) to a StructureDefinition resource; along with corresponding getter and setter methods
* **Publisher**
  * New Set\<FetchedResource\> variable **testscripts** to hold the list of all TestScript resources for the IG
  * **load()** method - new logic in iteration over the IG resources to populate the **testscripts** list; and populate each TestScript's **testProfiles** list
  * **generateSummaryOutputs()** method - new logic to iterate over all **testscripts** and for each linked Profile, update the corresponding StructureDefinition FetchedResource list of **foundTestScripts**
  * **addPageDataRow()** method - add new *testscripts* argument, passed in from profile processing; adds list of linked TestScripts to the Profile page