### PR TITLE
Enable -xig execution from Publisher jar

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -10260,7 +10260,7 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     } else if (hasNamedParam(args, "-go-publish")) {
       new PublicationProcess().publish(getNamedParam(args, "-source"), getNamedParam(args, "-destination"), hasNamedParam(args, "-milestone"), getNamedParam(args, "-registry"), getNamedParam(args, "-history"), getNamedParam(args, "-temp"));
     } else if (hasNamedParam(args, "-xig")) {
-      new XIGGenerator(getNamedParam(args, "-xig"));
+      new XIGGenerator(getNamedParam(args, "-xig")).execute();
     } else if (hasNamedParam(args, "-update-history")) {
       new HistoryPageUpdater().updateHistoryPages(getNamedParam(args, "-history"), getNamedParam(args, "-website"), getNamedParam(args, "-website"));
     } else if (hasNamedParam(args, "-publish-update")) {

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/utils/xig/XIGGenerator.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/utils/xig/XIGGenerator.java
@@ -137,7 +137,7 @@ public class XIGGenerator {
     return res;
   }
   
-  private void execute() throws IOException, ParserConfigurationException, SAXException, FHIRException, EOperationOutcome {
+  public void execute() throws IOException, ParserConfigurationException, SAXException, FHIRException, EOperationOutcome {
     PackageVisitor pv = new PackageVisitor();
     pv.getResourceTypes().add("CapabilityStatement");
     pv.getResourceTypes().add("SearchParameter");


### PR DESCRIPTION
The -xig option in the Publisher jar instantiated XIGGenerator, but didn't actually execute it.