### PR TITLE
Fix malformed html produced for the ip-statements.xhtml fragment.

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -9364,11 +9364,11 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
   // todo - hook this up to the
   private CopyRightUsageStatement getCopyRightStatement(String system) {
     if ("http://snomed.info/sct".equals(system)) {
-      return new CopyRightUsageStatement("SNOMED Clinical Terms® (SNOMED CT®)", "This content from  which is copyright of SNOMED International. Implementers of these specifications must have the appropriate SNOMED CT Affiliate license - "+
+      return new CopyRightUsageStatement("SNOMED Clinical Terms® (SNOMED CT®)", "This content is copyright of SNOMED International. Implementers of these specifications must have the appropriate SNOMED CT Affiliate license - "+
        "for more information contact <a href=\"http://www.snomed.org/snomed-ct/get-snomed-ct\">http://www.snomed.org/snomed-ct/get-snomed-ct</a> or <a href=\"mailto:info@snomed.org\">info@snomed.org</a>.");
     }
     if ("http://loinc.org".equals(system)) {
-      return new CopyRightUsageStatement("LOINC", "This material contains content from <a href=\"http://loinc.org\">LOINC</a. LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) "+
+      return new CopyRightUsageStatement("LOINC", "This material contains content from <a href=\"http://loinc.org\">LOINC</a>. LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) "+
          "Committee and is available at no cost under the <a href=\"http://loinc.org/license\">license</a>. LOINC® is a registered United States trademark of Regenstrief Institute, Inc.");
     }
     if (system != null) {
@@ -9384,6 +9384,7 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     if (Utilities.noString(p)) {
       return "";
     }
+    p = p.strip();
     if (p.startsWith("<p>")) {
       p = p.substring(3);
     }


### PR DESCRIPTION
Update the SNOMED CT and LOINC text in the getCopyRightStatement() function, and add a strip() statement to the stripPara() function logic so that the ending '\</p\>' suffix is detected and removed.