### PR TITLE
Catch xig render exceptions

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -2806,8 +2806,8 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
 
     loadIg("igtools", "hl7.fhir.uv.tools", "current", "http://hl7.org/fhir/tools/ImplementationGuide/hl7.fhir.uv.tools", i);    
     System.out.print("Load R5 Extensions");
-    R5ExtensionsLoader r5e = new R5ExtensionsLoader(pcm);
-    r5e.loadR5Extensions(context);
+    R5ExtensionsLoader r5e = new R5ExtensionsLoader(pcm, context);
+    r5e.loadR5Extensions();
     SpecMapManager smm = new SpecMapManager(r5e.getMap(), r5e.getPck().fhirVersion());
     smm.setName(r5e.getPck().name());
     smm.setBase("http://build.fhir.org");
@@ -9384,7 +9384,7 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     if (Utilities.noString(p)) {
       return "";
     }
-    p = p.strip();
+    p = p.trim();
     if (p.startsWith("<p>")) {
       p = p.substring(3);
     }

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -2806,8 +2806,8 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
 
     loadIg("igtools", "hl7.fhir.uv.tools", "current", "http://hl7.org/fhir/tools/ImplementationGuide/hl7.fhir.uv.tools", i);    
     System.out.print("Load R5 Extensions");
-    R5ExtensionsLoader r5e = new R5ExtensionsLoader(pcm, context);
-    r5e.loadR5Extensions();
+    R5ExtensionsLoader r5e = new R5ExtensionsLoader(pcm);
+    r5e.loadR5Extensions(context);
     SpecMapManager smm = new SpecMapManager(r5e.getMap(), r5e.getPck().fhirVersion());
     smm.setName(r5e.getPck().name());
     smm.setBase("http://build.fhir.org");

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/utils/xig/XIGRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/utils/xig/XIGRenderer.java
@@ -132,7 +132,12 @@ public class XIGRenderer extends XIGHandler implements ProfileKnowledgeProvider 
     System.out.println("Generate...");
     int i = 0;
     for (CanonicalResource cr : info.getResources().values()) {
-      renderResource(cr);
+      try {
+        renderResource(cr);
+      } catch (Exception e) {
+        Exception wrappedException = new Exception("Exception rendering canonical resource " + cr.getId() + " " + cr.getUrl(), e);
+        wrappedException.printStackTrace();
+      }
       i++;
       if (i > info.getResources().size() / 100) {
         System.out.print(".");

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <version>1.2.8-SNAPSHOT</version> <!-- See the note above -->
 
     <properties>
-        <core_version>5.6.71</core_version>
+        <core_version>5.6.71-SNAPSHOT</core_version>
         <maven.test.skip>true</maven.test.skip>
         <apache_poi_version>4.1.1</apache_poi_version>
     </properties>


### PR DESCRIPTION
Some packages contain content that can throw exceptions in the XIGRenderer renderResource(...) method.

This catches and reports those exceptions with additional information about the resource that caused them.