### PR TITLE
Add testscript fragment rendering to StructureDefinitions

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -9948,6 +9948,11 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     if (igpkp.wantGen(r, "example-table-all"))
       fragment("StructureDefinition-example-table-all-"+prefixForContainer+sd.getId(), sdr.exampleTable(fileList, false), f.getOutputNames(), r, vars, null);
 
+    if (igpkp.wantGen(r, "testscript-list"))
+      fragment("StructureDefinition-testscript-list-"+prefixForContainer+sd.getId(), sdr.testscriptList(fileList), f.getOutputNames(), r, vars, null);
+    if (igpkp.wantGen(r, "testscript-table"))
+      fragment("StructureDefinition-testscript-table-"+prefixForContainer+sd.getId(), sdr.testscriptTable(fileList), f.getOutputNames(), r, vars, null);
+
     String sdPrefix = newIg ? "StructureDefinition-" : "";
     if (igpkp.wantGen(r, "csv")) {
       String path = Utilities.path(tempDir, sdPrefix + r.getId()+".csv");

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
@@ -2149,6 +2149,52 @@ public class StructureDefinitionRenderer extends CanonicalRenderer {
     return b.toString();
   }
 
+  public String testscriptList(List<FetchedFile> fileList) {
+    StringBuilder b = new StringBuilder();
+    for (FetchedFile f : fileList) {
+      for (FetchedResource r : f.getResources()) {
+        if (r.fhirType().equals("TestScript")) {
+  	      for (String p : r.getTestArtifacts()) {
+            if (sd.getUrl().equals(p)) {
+              String name = r.getTitle();
+              if (Utilities.noString(name))
+                name = "TestScript";
+              String ref = igp.getLinkFor(r, true);
+              b.append(" <li><a href=\"" + Utilities.escapeXml(ref) + "\">" + Utilities.escapeXml(name) + "</a></li>\r\n");
+            }
+          }
+        }
+      }
+    }
+    return b.toString();
+  }
+
+  public String testscriptTable(List<FetchedFile> fileList) {
+    StringBuilder b = new StringBuilder();
+    for (FetchedFile f : fileList) {
+      for (FetchedResource r : f.getResources()) {
+        if (r.fhirType().equals("TestScript")) {
+          for (String p : r.getTestArtifacts()) {
+            if (sd.getUrl().equals(p)) {
+              String name = r.fhirType() + "/" + r.getId();
+              String title = r.getTitle();
+              if (Utilities.noString(title))
+                name = "TestScript";
+              if (f.getTitle() != null && f.getTitle() != f.getName())
+                title = f.getTitle();
+              String ref = igp.getLinkFor(r, true);
+              b.append(" <tr>\r\n");
+              b.append("   <td><a href=\"" + Utilities.escapeXml(ref) + "\">" + Utilities.escapeXml(name) + "</a></td>\r\n");
+              b.append("   <td>" + Utilities.escapeXml(title) + "</td>\r\n");
+              b.append(" </tr>\r\n");
+            }
+          }
+        }
+      }
+    }
+    return b.toString();
+  }
+
   public String span(boolean onlyConstraints, String canonical, Set<String> outputTracker) throws IOException, FHIRException {
     return new XhtmlComposer(XhtmlComposer.HTML).compose(utils.generateSpanningTable(sd, destDir, onlyConstraints, canonical, outputTracker));
   }


### PR DESCRIPTION
### What does this Pull Request do?
Add logic to generate TestScript list and table html fragments for Profiles (StructureDefinitions).

### How?
Minor code additions to two (2) classes that provide the needed functionality to generate the TestScript html fragments for StructureDefinitions:
* **StructureDefinitionRenderer** 
  * New method **testscriptList()** to generate the TestScript list html fragment
  * New method **testscriptTable()** to generate the TestScript table html fragment
* **Publisher**
  * **generateOutputsStructureDefinition()** method - new logic modeled after example list and table generation to conditionally call the new **StructureDefinitionRenderer** class methods **testscriptList()** and **testscriptTable()** based on the template config settings **testscript-list** and **testscript-table**.