### PR TITLE
NPE in PublicationChecker.checkFolder

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/PublicationChecker.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/PublicationChecker.java
@@ -89,7 +89,7 @@ public class PublicationChecker {
         try {
           pl = readPackageList(dst);
         } catch (Exception e) {
-          if (e.getMessage().contains("404")) {
+          if (e.getMessage() != null && e.getMessage().contains("404")) {
             messages.add("<span title=\""+Utilities.escapeXml(e.getMessage())+"\">This IG has never been published</span>"+mkInfo());
           } else {            
             check(messages, false, "Error fetching package-list from "+dst+": "+e.getMessage()+mkError());


### PR DESCRIPTION
A null-pointer exception occurs if exception does not contain a message. This can happen for example if retrieval was successful, but package-list.json is not parseable as a json file.

Specific scenario is an unpublished IG where the canonical url leads to a web server that has a default redirect to a html page.