### PR TITLE
Sushi: only right-trim logs to increase readability

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -2320,7 +2320,7 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
       if (b == 10) { // eoln
         String s = new String(buffer, 0, length);
         if (passSushiFilter(s)) {
-          log("Sushi: "+s.trim());
+          log("Sushi: "+StringUtils.stripEnd(s, null));
           if (s.trim().startsWith("Errors:")) {
             errorCount = Integer.parseInt(s.substring(10).trim());
           }


### PR DESCRIPTION
Sushi logs are trimmed on both sides in MySushiHandler. This leads to removing part of ANSI escape codes used for output coloring and removing indentation of some lines (e.g. when an error arises, Sushi idents the lines "File", "Line", "Applied" for better readability). The logs should only be right-trimmed (to remove \r\n).

Before:
![before](https://user-images.githubusercontent.com/3299399/203787037-97feea22-7578-465c-8a98-dd140501d0b5.png)

After:
![after](https://user-images.githubusercontent.com/3299399/203787057-b71a78e6-9bb2-4d4b-b35a-80deb7cbc9ab.png)
