### PR TITLE
Add GraalVM js engine

### DIFF
--- a/org.hl7.fhir.publisher.core/pom.xml
+++ b/org.hl7.fhir.publisher.core/pom.xml
@@ -12,6 +12,10 @@
 
     <artifactId>org.hl7.fhir.publisher.core</artifactId>
 
+    <properties>
+        <graalvm.version>22.2.0</graalvm.version>
+    </properties>
+
     <dependencies>
 
         <dependency>
@@ -101,6 +105,16 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>1.1.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+            <version>${graalvm.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js-scriptengine</artifactId>
+            <version>${graalvm.version}</version>
         </dependency>
 <!--   TODO, figure out why this causes issues     -->
 <!--        <dependency>-->

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.10.11</version>
+                <version>1.10.12</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Since Java 15, there is no longer a default JavaScript engine within the JVM.

The publisher uses Ant build files which are processed via org.apache.ant, which requires a JavaScript engine.

This adds GraalVM as the default engine for this purpose via dependencies, and should allow Java 11 and 17 to run JavaScript script within Ant build files.

**This is presently only working via direct execution in IntelliJ. Somehow, the process of packaging Graal into the CLI jar is not working correctly.**