### PR TITLE
Fix SUSHI require-latest logic

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -2349,7 +2349,10 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     exec.setWorkingDirectory(file);
     ExecuteWatchdog watchdog = new ExecuteWatchdog(fshTimeout);
     exec.setWatchdog(watchdog);
-    String cmd = fshVersion == null ? "sushi" : "npx fsh-sushi@"+fshVersion+(mode == IGBuildMode.PUBLICATION || mode == IGBuildMode.AUTOBUILD ? "--require-latest" : "");
+    String cmd = fshVersion == null ? "sushi" : "npx fsh-sushi@"+fshVersion;
+    if (mode == IGBuildMode.PUBLICATION || mode == IGBuildMode.AUTOBUILD) {
+      cmd += " --require-latest";
+    }
     try {
       if (SystemUtils.IS_OS_WINDOWS) {
         exec.execute(org.apache.commons.exec.CommandLine.parse("cmd /C "+cmd+" . -o ."));


### PR DESCRIPTION
This fixes two issues with the logic for applying the `--require-latest` flag to SUSHI:
1. It adds the missing `" "` (space) between the command and the flag. Prior to this fix, the cmd would contain `fsh-sushi@2.8.0--require-latest` instead of `fsh-sushi@2.8.0 --require-latest`.
2. It applies the flag whether or not `fsh.ini` is used to specify a version. Prior to this fix, it only applied the flag when a version was specified in `fsh.ini`. I don't think this was the intent.

I'd also like to propose relaxing use of `--require-latest` in CI builds. Sometimes setting a specific version is helpful to avoid a recently introduced breaking change or to use a beta version of FSH before it is released. I think it's reasonable for projects to use this in CI up until they're ready for publication. That said, if the core team feels strongly that `--require-latest` should be enforced in CI, then can we enforce it _only_ for HL7 IGs? If you agree, I can update this PR to also relax those requirements.