### PR TITLE
add fml support for StructureMap in ig

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -4222,7 +4222,7 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
           igpkp.findConfiguration(f, r);
       }
       // TestScript Check
-      if (res.getReference().getReference().contains("TestScript")) {
+      if (res.getReference().getReference().contains("TestScript") && !res.getReference().getReference().startsWith("StructureMap")) {
         if (f == null) {
           f = fetcher.fetch(res.getReference(), igf);
         }
@@ -5507,18 +5507,13 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
   }
 
   private Element loadFromMap(FetchedFile file) throws Exception {
-    if (VersionUtilities.isR4Ver(context.getVersion()) || VersionUtilities.isR4BVer(context.getVersion())) {
-      StructureMapUtilities mr = new StructureMapUtilities(context);
-      FmlParser fp = new FmlParser(context);
-      fp.setupValidation(ValidationPolicy.EVERYTHING, file.getErrors());     
-      Element res = fp.parse(TextFile.bytesToString(file.getSource()));
-      if (res == null) {
-        throw new Exception("Unable to parse Map Source for "+file.getName());
-      }
-      return res;      
-    } else {
-      throw new Error("Loading Map Files is not supported for version "+VersionUtilities.getNameForVersion(context.getVersion()));
+    FmlParser fp = new FmlParser(context);
+    fp.setupValidation(ValidationPolicy.EVERYTHING, file.getErrors());     
+    Element res = fp.parse(TextFile.bytesToString(file.getSource()));
+    if (res == null) {
+      throw new Exception("Unable to parse Map Source for "+file.getName());
     }
+    return res;      
   }
 
   private Element loadFromXml(FetchedFile file) throws Exception {
@@ -6070,6 +6065,9 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
         res = new org.hl7.fhir.dstu3.formats.JsonParser(true).parse(source);
       } else if (contentType.contains("xml")) {
         res = new org.hl7.fhir.dstu3.formats.XmlParser(true).parse(source);
+      } else if (contentType.contains("fml")) {
+        StructureMapUtilities mu = new StructureMapUtilities(context, null, null);
+        return mu.parse(new String(source), "");
       } else {
         throw new Exception("Unable to determine file type for "+name);
       }
@@ -6080,6 +6078,9 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
         res = new org.hl7.fhir.r4.formats.JsonParser(true, true).parse(source);
       } else if (contentType.contains("xml")) {
         res = new org.hl7.fhir.r4.formats.XmlParser(true).parse(source);
+      } else if (contentType.contains("fml")) {
+        StructureMapUtilities mu = new StructureMapUtilities(context, null, null);
+        return mu.parse(new String(source), "");
       } else {
         throw new Exception("Unable to determine file type for "+name);
       }
@@ -6090,6 +6091,9 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
         res = new org.hl7.fhir.dstu2016may.formats.JsonParser(true).parse(source);
       } else if (contentType.contains("xml")) {
         res = new org.hl7.fhir.dstu2016may.formats.XmlParser(true).parse(source);
+      } else if (contentType.contains("fml")) {
+        StructureMapUtilities mu = new StructureMapUtilities(context, null, null);
+        return mu.parse(new String(source), "");
       } else {
         throw new Exception("Unable to determine file type for "+name);
       }
@@ -6100,6 +6104,9 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
         res = new org.hl7.fhir.dstu2.formats.JsonParser(true).parse(source);
       } else if (contentType.contains("xml")) {
         res = new org.hl7.fhir.dstu2.formats.XmlParser(true).parse(source);
+      } else if (contentType.contains("fml")) {
+        StructureMapUtilities mu = new StructureMapUtilities(context, null, null);
+        return mu.parse(new String(source), "");
       } else {
         throw new Exception("Unable to determine file type for "+name);
       }
@@ -6112,6 +6119,9 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
         res = new org.hl7.fhir.r4b.formats.JsonParser(true).parse(source);
       } else if (contentType.contains("xml")) {
         res = new org.hl7.fhir.r4b.formats.XmlParser(true).parse(source);
+      } else if (contentType.contains("fml")) {
+        StructureMapUtilities mu = new StructureMapUtilities(context, null, null);
+        return mu.parse(new String(source), "");
       } else {
         throw new Exception("Unable to determine file type for "+name);
       }
@@ -6121,6 +6131,9 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
         return new JsonParser(true, true).parse(source);
       } else if (contentType.contains("xml")) {
         return new XmlParser(true).parse(source);
+      } else if (contentType.contains("fml")) {
+        StructureMapUtilities mu = new StructureMapUtilities(context, null, null);
+        return mu.parse(new String(source), "");
       } else {
         throw new Exception("Unable to determine file type for "+name);
       }


### PR DESCRIPTION
this PR extends the IG support that
- fml files are converted to StructureMap resources and included in the IG package
- fml are converted with R5 (not only R4 and R4B)

goal is to build an ig (another PR for the packages/inteversion/r5) will follow

i'm not very familiar with the inner workings of ig publisher, had to add the map parsing at 3 different places, so a review, adapation would be appreciated
