### PR TITLE
Fix github branch name retrieval

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/GitUtilities.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/GitUtilities.java
@@ -1,17 +1,25 @@
 package org.hl7.fhir.igtools.publisher;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 
 public class GitUtilities {
 
 	protected static String execAndReturnString(String[] cmd, String[] env, File directory) throws IOException, InterruptedException {
-		String output = "";
+
 		Process p = Runtime.getRuntime().exec(cmd, null, directory);
-		InputStreamReader isr = new InputStreamReader(p.getInputStream());
-		p.waitFor();
+		int result = p.waitFor();
+
+		if (result == 0) {
+			return toString(p.getInputStream());
+		}
+
+		String error = toString(p.getErrorStream());
+		throw new RuntimeException(error);
+	}
+
+	private static String toString(InputStream inputStream) throws InterruptedException, IOException {
+		String output = "";
+		InputStreamReader isr = new InputStreamReader(inputStream);
 		BufferedReader br = new BufferedReader(isr);
 		String line;
 		while ((line = br.readLine()) != null) {
@@ -19,6 +27,7 @@ public class GitUtilities {
 		}
 		return output;
 	}
+
 	public static String getGitStatus(File gitDir) {
 	  if (!gitDir.exists()) {
 		return "";

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/GitUtilities.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/GitUtilities.java
@@ -1,15 +1,31 @@
 package org.hl7.fhir.igtools.publisher;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
 
 public class GitUtilities {
+
+	protected static String execAndReturnString(String[] cmd, String[] env, File directory) throws IOException, InterruptedException {
+		String output = "";
+		Process p = Runtime.getRuntime().exec(cmd, null, directory);
+		InputStreamReader isr = new InputStreamReader(p.getInputStream());
+		p.waitFor();
+		BufferedReader br = new BufferedReader(isr);
+		String line;
+		while ((line = br.readLine()) != null) {
+			output += line;
+		}
+		return output;
+	}
 	public static String getGitStatus(File gitDir) {
 	  if (!gitDir.exists()) {
 		return "";
 	  }
 	  try {
 		String[] cmd = { "git", "rev-parse", "--abbrev-ref"," HEAD" };
-		return Publisher.execAndReturnString(cmd, new String[]{}, gitDir);
+		return execAndReturnString(cmd, new String[]{}, gitDir);
 	  } catch (Exception e) {
 		System.out.println("Warning @ Unable to read the git branch: " + e.getMessage() );
 		return "";

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/GitUtilities.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/GitUtilities.java
@@ -24,7 +24,7 @@ public class GitUtilities {
 		return "";
 	  }
 	  try {
-		String[] cmd = { "git", "rev-parse", "--abbrev-ref"," HEAD" };
+		String[] cmd = { "git", "branch", "--show-current" };
 		return execAndReturnString(cmd, new String[]{}, gitDir);
 	  } catch (Exception e) {
 		System.out.println("Warning @ Unable to read the git branch: " + e.getMessage() );

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/GitUtilities.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/GitUtilities.java
@@ -1,0 +1,18 @@
+package org.hl7.fhir.igtools.publisher;
+
+import java.io.File;
+
+public class GitUtilities {
+	public static String getGitStatus(File gitDir) {
+	  if (!gitDir.exists()) {
+		return "";
+	  }
+	  try {
+		String[] cmd = { "git", "rev-parse", "--abbrev-ref"," HEAD" };
+		return Publisher.execAndReturnString(cmd, new String[]{}, gitDir);
+	  } catch (Exception e) {
+		System.out.println("Warning @ Unable to read the git branch: " + e.getMessage() );
+		return "";
+	  }
+	}
+}

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -8576,18 +8576,7 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     return businessVersion == null ? publishedIg.getVersion() : businessVersion;
   }
 
-  protected static String execAndReturnString(String[] cmd, String[] env, File directory) throws IOException, InterruptedException {
-    String output = "";
-    Process p = Runtime.getRuntime().exec(cmd, null, directory);
-    InputStreamReader isr = new InputStreamReader(p.getInputStream());
-    p.waitFor();
-    BufferedReader br = new BufferedReader(isr);
-    String line;
-    while ((line = br.readLine()) != null) {
-      output += line;
-    }
-    return output;
-  }
+
 
   private String getGitStatus() throws IOException {
     File gitDir = new File(Utilities.getDirectoryForFile(configFile));

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -8576,13 +8576,22 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
     return businessVersion == null ? publishedIg.getVersion() : businessVersion;
   }
 
-  private String getGitStatus() throws IOException {
-    File gitDir = new File(Utilities.path(Utilities.getDirectoryForFile(configFile), ".git"));
-    if (!gitDir.exists()) {
-      return "";      
+  protected static String execAndReturnString(String[] cmd, String[] env, File directory) throws IOException, InterruptedException {
+    String output = "";
+    Process p = Runtime.getRuntime().exec(cmd, null, directory);
+    InputStreamReader isr = new InputStreamReader(p.getInputStream());
+    p.waitFor();
+    BufferedReader br = new BufferedReader(isr);
+    String line;
+    while ((line = br.readLine()) != null) {
+      output += line;
     }
-    String head = TextFile.fileToString(Utilities.path(gitDir.getAbsolutePath(), "HEAD")).trim();
-    return head.substring(head.lastIndexOf("/")+1);
+    return output;
+  }
+
+  private String getGitStatus() throws IOException {
+    File gitDir = new File(Utilities.getDirectoryForFile(configFile));
+    return GitUtilities.getGitStatus(gitDir);
   }
 
   private void generateResourceReferences() throws Exception {

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -14,13 +14,13 @@ public class GitUtilitiesTests {
 	@Test
 	public void testGetGitStatus() {
 		String output = GitUtilities.getGitStatus(Path.of(new File(System.getProperty("user.dir")).getAbsolutePath(), "src/test/resources/git/regular-branch/").toFile());
-		assertEquals("HEAD", output.trim());
+		assertEquals("main", output.trim());
 	}
 
 	@Test
 	public void testGetGitWorktreeStatus() {
 		String output = GitUtilities.getGitStatus(Path.of(new File(System.getProperty("user.dir")).getAbsolutePath(), "src/test/resources/git/worktree-branch/").toFile());
-		assertEquals("HEAD", output.trim());
+		assertEquals("branch-a", output.trim());
 	}
 	@Test
 	public void testGitStatusWhenNotGitDirectory() throws IOException {

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 
 import java.nio.file.Files;
@@ -33,9 +35,13 @@ public class GitUtilitiesTests {
 
 		File dummyFile = Path.of(normalBranchDirectory.getAbsolutePath().toString(), "dummy.txt").toFile();
 		dummyFile.createNewFile();
-		//System.out.println(execAndReturnString(new String[]{"touch", "dummy.txt"}, null, normalBranchDirectory));
 
-		System.out.println(execAndReturnString(new String[]{"git", "add", "./dummy.txt"},null, normalBranchDirectory));
+		BufferedWriter writer = new BufferedWriter(new FileWriter(dummyFile));
+		writer.write("dummy content");
+
+		writer.close();
+
+		System.out.println(execAndReturnString(new String[]{"git", "add", "dummy.txt"},null, normalBranchDirectory));
 		System.out.println(execAndReturnString(new String[]{"git", "commit", "-m", "test"},null, normalBranchDirectory));
 		System.out.println(execAndReturnString(new String[]{"git", "branch", "branch-a"}, null, normalBranchDirectory));
 

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -30,7 +30,10 @@ public class GitUtilitiesTests {
 		Path worktreeBranchPath = Path.of(gitRoot.getAbsolutePath(), "branch-a");
 
 		System.out.println(execAndReturnString(new String[]{"git", "init"}, null, normalBranchDirectory));
-		System.out.println(execAndReturnString(new String[]{"touch", "dummy.txt"}, null, normalBranchDirectory));
+
+		File dummyFile = Path.of(normalBranchDirectory.getAbsolutePath().toString(), "dummy.txt").toFile();
+		dummyFile.createNewFile();
+		//System.out.println(execAndReturnString(new String[]{"touch", "dummy.txt"}, null, normalBranchDirectory));
 
 		System.out.println(execAndReturnString(new String[]{"git", "add", "./dummy.txt"},null, normalBranchDirectory));
 		System.out.println(execAndReturnString(new String[]{"git", "commit", "-m", "test"},null, normalBranchDirectory));

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -33,6 +33,9 @@ public class GitUtilitiesTests {
 
 		System.out.println(execAndReturnString(new String[]{"git", "init"}, null, normalBranchDirectory));
 
+		//git config --global user.email "you@example.com"
+		System.out.println(execAndReturnString(new String[]{"git", "config", "user.email", "\"dummy@dummy.org\""}, null, normalBranchDirectory));
+
 		File dummyFile = Path.of(normalBranchDirectory.getAbsolutePath().toString(), "dummy.txt").toFile();
 		dummyFile.createNewFile();
 

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -13,13 +13,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class GitUtilitiesTests {
 	@Test
 	public void testGetGitStatus() {
-		String output = GitUtilities.getGitStatus(Path.of(new File(System.getProperty("user.dir")).getAbsolutePath(), "src/test/resources/git/regular-branch/").toFile());
+		String output = GitUtilities.getGitStatus(new File("src/test/resources/git/regular-branch/"));
 		assertEquals("main", output.trim());
 	}
 
 	@Test
 	public void testGetGitWorktreeStatus() {
-		String output = GitUtilities.getGitStatus(Path.of(new File(System.getProperty("user.dir")).getAbsolutePath(), "src/test/resources/git/worktree-branch/").toFile());
+		String output = GitUtilities.getGitStatus(new File("src/test/resources/git/worktree-branch/"));
 		assertEquals("branch-a", output.trim());
 	}
 	@Test

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -35,6 +35,9 @@ public class GitUtilitiesTests {
 		System.out.println(execAndReturnString(new String[]{"git", "add", "./dummy.txt"},null, normalBranchDirectory));
 		System.out.println(execAndReturnString(new String[]{"git", "commit", "-m", "test"},null, normalBranchDirectory));
 		System.out.println(execAndReturnString(new String[]{"git", "branch", "branch-a"}, null, normalBranchDirectory));
+
+		System.out.println(execAndReturnString(new String[]{"git", "checkout", "-b", "branch-b"}, null, normalBranchDirectory));
+
 		System.out.println(execAndReturnString(new String[]{"git", "worktree", "add", worktreeBranchPath.toString(), "branch-a"}, null, normalBranchDirectory));
 
 		worktreeBranchDirectory = worktreeBranchPath.toFile();
@@ -42,7 +45,7 @@ public class GitUtilitiesTests {
 	@Test
 	public void testGetGitStatus() {
 		String output = GitUtilities.getGitStatus(normalBranchDirectory);
-		assertEquals("main", output.trim());
+		assertEquals("branch-b", output.trim());
 	}
 
 	@Test

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -1,25 +1,53 @@
 package org.hl7.fhir.igtools.publisher;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.io.File;
 import java.io.IOException;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import static org.hl7.fhir.igtools.publisher.GitUtilities.execAndReturnString;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class GitUtilitiesTests {
+
+	File normalBranchDirectory;
+	File worktreeBranchDirectory;
+	@BeforeAll
+	public void beforeAll() throws IOException, InterruptedException {
+		File gitRoot = Files.createTempDirectory("testGitDirectory").toFile();
+
+		normalBranchDirectory = Path.of(gitRoot.getAbsolutePath(),"normal-branch").toFile();
+		normalBranchDirectory.mkdir();
+
+		Path worktreeBranchPath = Path.of(gitRoot.getAbsolutePath(), "branch-a");
+
+		System.out.println(execAndReturnString(new String[]{"git", "init"}, null, normalBranchDirectory));
+		System.out.println(execAndReturnString(new String[]{"touch", "dummy.txt"}, null, normalBranchDirectory));
+
+		System.out.println(execAndReturnString(new String[]{"git", "add", "./dummy.txt"},null, normalBranchDirectory));
+		System.out.println(execAndReturnString(new String[]{"git", "commit", "-m", "test"},null, normalBranchDirectory));
+		System.out.println(execAndReturnString(new String[]{"git", "branch", "branch-a"}, null, normalBranchDirectory));
+		System.out.println(execAndReturnString(new String[]{"git", "worktree", "add", worktreeBranchPath.toString(), "branch-a"}, null, normalBranchDirectory));
+
+		worktreeBranchDirectory = worktreeBranchPath.toFile();
+	}
 	@Test
 	public void testGetGitStatus() {
-		String output = GitUtilities.getGitStatus(new File("src/test/resources/git/regular-branch/"));
+		String output = GitUtilities.getGitStatus(normalBranchDirectory);
 		assertEquals("main", output.trim());
 	}
 
 	@Test
 	public void testGetGitWorktreeStatus() {
-		String output = GitUtilities.getGitStatus(new File("src/test/resources/git/worktree-branch/"));
+		String output = GitUtilities.getGitStatus(worktreeBranchDirectory);
 		assertEquals("branch-a", output.trim());
 	}
 	@Test

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -36,6 +36,8 @@ public class GitUtilitiesTests {
 		//git config --global user.email "you@example.com"
 		System.out.println(execAndReturnString(new String[]{"git", "config", "user.email", "\"dummy@dummy.org\""}, null, normalBranchDirectory));
 
+		System.out.println(execAndReturnString(new String[]{"git", "config", "user.name", "\"guyincognito\""}, null, normalBranchDirectory));
+
 		File dummyFile = Path.of(normalBranchDirectory.getAbsolutePath().toString(), "dummy.txt").toFile();
 		dummyFile.createNewFile();
 

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -1,0 +1,23 @@
+package org.hl7.fhir.igtools.publisher;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GitUtilitiesTests {
+	@Test
+	public void testGetGitStatus() {
+		String output = GitUtilities.getGitStatus(new File(System.getProperty("user.dir")));
+		assertTrue(output.length() > 0);
+	}
+
+	@Test
+	public void testGitStatusWhenNotGitDirectory() throws IOException {
+		String output = GitUtilities.getGitStatus(Files.createTempDirectory("emptyNonGitDirectory").toFile());
+		assertTrue(output.length() == 0);
+	}
+}

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -5,16 +5,23 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GitUtilitiesTests {
 	@Test
 	public void testGetGitStatus() {
-		String output = GitUtilities.getGitStatus(new File(System.getProperty("user.dir")));
-		assertTrue(output.length() > 0);
+		String output = GitUtilities.getGitStatus(Path.of(new File(System.getProperty("user.dir")).getAbsolutePath(), "src/test/resources/git/regular-branch/").toFile());
+		assertEquals("HEAD", output.trim());
 	}
 
+	@Test
+	public void testGetGitWorktreeStatus() {
+		String output = GitUtilities.getGitStatus(Path.of(new File(System.getProperty("user.dir")).getAbsolutePath(), "src/test/resources/git/worktree-branch/").toFile());
+		assertEquals("HEAD", output.trim());
+	}
 	@Test
 	public void testGitStatusWhenNotGitDirectory() throws IOException {
 		String output = GitUtilities.getGitStatus(Files.createTempDirectory("emptyNonGitDirectory").toFile());

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -41,7 +41,7 @@ public class GitUtilitiesTests {
 
 		writer.close();
 
-		System.out.println(execAndReturnString(new String[]{"git", "add", "dummy.txt"},null, normalBranchDirectory));
+		System.out.println(execAndReturnString(new String[]{"git", "add", "--all"},null, normalBranchDirectory));
 		System.out.println(execAndReturnString(new String[]{"git", "commit", "-m", "test"},null, normalBranchDirectory));
 		System.out.println(execAndReturnString(new String[]{"git", "branch", "branch-a"}, null, normalBranchDirectory));
 


### PR DESCRIPTION
Fix for https://github.com/HL7/fhir-ig-publisher/issues/634

Using git worktree created directories was not working correctly with ig publisher. This swaps out the logic by which we get git branch with a more robust and straightforward command.