### PR TITLE
Fix HTMLInspector paths that fail in Windows

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
@@ -639,7 +639,7 @@ public class HTMLInspector {
     }
     
     if (!resolved && !Utilities.isAbsoluteUrl(ref) && !rref.startsWith("#")) {
-      String fref = buildRef(filename, ref);
+      String fref = buildRef(Utilities.getDirectoryForFile(filename), ref);
       if (fref.equals(Utilities.path(rootFolder, "qa.html"))) {
         resolved = true;
       }
@@ -721,10 +721,10 @@ public class HTMLInspector {
   }
 
   @NotNull
-  private String buildRef(String filename, String ref) throws IOException {
+  private String buildRef(String refParentPath, String ref) throws IOException {
     //FIXME This logic should be in Utilities.path
     // Utilities path does checks for
-    return Utilities.path(Utilities.getDirectoryForFile(filename)) + File.separator + ref;
+    return Utilities.path(refParentPath) + File.separator + ref;
   }
 
   private boolean matchesTarget(String ref, String... url) {

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
@@ -55,6 +55,7 @@ import org.hl7.fhir.utilities.xhtml.XhtmlComposer;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode;
 import org.hl7.fhir.utilities.xhtml.XhtmlNode.Location;
 import org.hl7.fhir.utilities.xhtml.XhtmlParser;
+import org.jetbrains.annotations.NotNull;
 
 //import org.owasp.html.Handler;
 //import org.owasp.html.HtmlChangeListener;
@@ -638,8 +639,7 @@ public class HTMLInspector {
     }
     
     if (!resolved && !Utilities.isAbsoluteUrl(ref)) {
-      //FIXME This logic should be in Utilities.path
-      String fref = Utilities.path(Utilities.getDirectoryForFile(filename)) + File.separator + ref;
+      String fref = buildRef(filename, ref);
       if (fref.equals(Utilities.path(rootFolder, "qa.html"))) {
         resolved = true;
       }
@@ -657,7 +657,7 @@ public class HTMLInspector {
      }
      // a local file may have been created by some poorly tracked process, so we'll consider that as a possible
      if (!resolved && !Utilities.isAbsoluteUrl(rref) && !rref.contains("..")) { // .. is security check. Maybe there's some ways it could be valid, but we're not interested for now
-       String fname = Utilities.path(new File(filename).getParent(), rref);
+       String fname = buildRef(new File(filename).getParent(), rref);
        if (new File(fname).exists()) {
          resolved = true;
        }
@@ -718,6 +718,12 @@ public class HTMLInspector {
       messages.add(new ValidationMessage(Source.LinkChecker, IssueType.NOTFOUND, filename+(path == null ? "" : "#"+path+(loc == null ? "" : " at "+loc.toString())), "The link '"+ref+"' for \""+text.replaceAll("[\\s\\n]+", " ").trim()+"\" cannot be resolved"+tgtList, IssueSeverity.ERROR).setLocationLink(uuid == null ? null : makeLocal(filename)+"#"+uuid));
       return true;
     } 
+  }
+
+  @NotNull
+  private String buildRef(String filename, String ref) throws IOException {
+    //FIXME This logic should be in Utilities.path
+    return Utilities.path(Utilities.getDirectoryForFile(filename)) + File.separator + ref;
   }
 
   private boolean matchesTarget(String ref, String... url) {

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
@@ -638,7 +638,8 @@ public class HTMLInspector {
     }
     
     if (!resolved && !Utilities.isAbsoluteUrl(ref)) {
-      String fref = Utilities.path(Utilities.getDirectoryForFile(filename), ref);
+      //FIXME This logic should be in Utilities.path
+      String fref = Utilities.path(Utilities.getDirectoryForFile(filename)) + File.separator + ref;
       if (fref.equals(Utilities.path(rootFolder, "qa.html"))) {
         resolved = true;
       }

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
@@ -723,6 +723,7 @@ public class HTMLInspector {
   @NotNull
   private String buildRef(String filename, String ref) throws IOException {
     //FIXME This logic should be in Utilities.path
+    // Utilities path does checks for
     return Utilities.path(Utilities.getDirectoryForFile(filename)) + File.separator + ref;
   }
 

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
@@ -723,7 +723,8 @@ public class HTMLInspector {
   @NotNull
   private String buildRef(String refParentPath, String ref) throws IOException {
     //FIXME This logic should be in Utilities.path
-    // Utilities path does checks for
+    // Utilities path will try to assemble a filesystem path,
+    // and this will fail in Windows if it contains ':' characters.
     return Utilities.path(refParentPath) + File.separator + ref;
   }
 


### PR DESCRIPTION
Utilities.path constructs java Path instances to ensure that Paths aren't doing anything nefarious, but the two instances here construct 'kinda' paths with filesystem paths that have anchors ('C:/myig/somefile.html#extension:somethingelse') which can contain illegal characters in the Windows OS. 

Utilities.path should have a way to deal with this, but until then, this works around it. 