### PR TITLE
Prevent checks for URL templates as directories

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/templates/TemplateManager.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/templates/TemplateManager.java
@@ -250,7 +250,7 @@ public class TemplateManager {
         return pcm.loadPackage(p[0], p[1]);
       }
       File f = new File(template);
-      if (!f.exists()) {
+      if (!f.exists() && !Utilities.isURL(template)) {
         f = new File(Utilities.path(rootFolder, template));
       }
       if (f.exists()) {


### PR DESCRIPTION
When a template is a URL, it will resolve as a path under Linux/Max filesystems, but will break in Windows.

This skips attempting to check URLs as possible local directories when loading a template.