### PR TITLE
Fix typo in R6 support

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -3447,7 +3447,7 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
       vs = "hl7.terminology.r4";
     } else if (VersionUtilities.isR5Ver(version)) {
       vs = "hl7.terminology.r5";
-    } else if (VersionUtilities.isR5Ver(version)) {
+    } else if (VersionUtilities.isR6Ver(version)) {
       vs = "hl7.terminology.r6";
     }
     return vs;


### PR DESCRIPTION
The R5 condition was duplicated. Fixes e1d61c4.