### PR TITLE
Suppress mappings that are totally empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,4 @@ local.properties
 /org.hl7.fhir.publisher.core/full-ig.zip
 
 FHIR-us-pq-cmc
+.vscode/


### PR DESCRIPTION
If we suppress mappings that are all empty - then the `-maps-diff` HTML fragment will contain only the mappings that you've added in your differential. 

Make use of custom template to use `-maps-diff` rather than `-map` HTML fragment gets a much more useful Mappings tab in the StructureDefinition.

While I'm here, I made the `comment` column a markdown field.