### PR TITLE
Add urn prefix to rref special cases in HTMLInspector.checkResolveLink

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/HTMLInspector.java
@@ -677,7 +677,7 @@ public class HTMLInspector {
      }
     
     if (!resolved) {
-      if (rref.startsWith("http://") || rref.startsWith("https://") || rref.startsWith("ftp://") || rref.startsWith("tel:")) {
+      if (rref.startsWith("http://") || rref.startsWith("https://") || rref.startsWith("ftp://") || rref.startsWith("tel:") || rref.startsWith("urn:")) {
         resolved = true;
         if (specs != null) {
           for (SpecMapManager spec : specs) {


### PR DESCRIPTION
urns are being treated as files by checkResolveLink, which creates issues in Windows, where ":" is an illegal character.

Example:

```log
java.nio.file.InvalidPathException: Illegal char <:> at index 28: c:\FHIR-us-pq-cmc\output\urn:uuid:c503d743-ddf4-4dea-9a97-c65a20c1274e
```