### PR TITLE
Fix invalid filename path check in DICOM

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/SpecMapManager.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/SpecMapManager.java
@@ -22,6 +22,8 @@ package org.hl7.fhir.igtools.publisher;
 
 
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -187,7 +189,10 @@ public class SpecMapManager {
         return str(spec, "webUrl")+"/"+rt.toLowerCase()+"-"+id.toLowerCase()+".html";
       case DICOM:
         try {
-          if (pi.hasFile("package", Utilities.urlTail(url)+"json") || pi.hasCanonical(url)) {
+          final String fileName = Utilities.urlTail(url) + "json";
+
+          if ((isValidFilename(fileName) && pi.hasFile("package", fileName))
+                  || pi.hasCanonical(url)) {
             return url;
           } else {
             return null;
@@ -212,6 +217,15 @@ public class SpecMapManager {
     }
     
     return null;
+  }
+
+  public boolean isValidFilename(String filename) {
+    try {
+      Paths.get(filename);
+    } catch (InvalidPathException e) {
+      return false;
+    }
+    return true;
   }
 
   // hack around things missing in spec.internals 


### PR DESCRIPTION
SpecMapManager is running a special case check for files in DICOM, but asks for some filenames invalid in Windows.