### PR TITLE
Catch missing path entry in package-registry.json

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/PackageRegistryBuilder.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/PackageRegistryBuilder.java
@@ -36,7 +36,7 @@ public class PackageRegistryBuilder {
     JsonObject e = null;
     for (JsonObject t : json.forceArray("packages").asJsonObjects()) {
       if (!t.has("path")) {
-        throw new IllegalArgumentException("package entry in package-list.json is missing path entry: " + t.toString());
+        throw new IllegalArgumentException("package entry in package-registry.json is missing path entry: " + t.toString());
       }
       if (t.asString("path").equals(path)) {
         e = t;

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/PackageRegistryBuilder.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/PackageRegistryBuilder.java
@@ -22,7 +22,7 @@ public class PackageRegistryBuilder {
     this.rootFolder = rootFolder;
   }
 
-  private File prFile() throws IOException {
+  protected File prFile() throws IOException {
     return new File(Utilities.path(rootFolder, "package-registry.json"));
   }
 
@@ -35,6 +35,9 @@ public class PackageRegistryBuilder {
   private void update(JsonObject json, String path, PackageList pl) {
     JsonObject e = null;
     for (JsonObject t : json.forceArray("packages").asJsonObjects()) {
+      if (!t.has("path")) {
+        throw new IllegalArgumentException("package entry in package-list.json is missing path entry: " + t.toString());
+      }
       if (t.asString("path").equals(path)) {
         e = t;
         break;
@@ -72,7 +75,7 @@ public class PackageRegistryBuilder {
       jv.add("date", ple.date());
       jv.add("path", ple.path());
       e.add("milestone", jv);
-    }    
+    }
   }
   
   public void build() throws IOException {

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/web/PackageRegistryBuilderTest.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/web/PackageRegistryBuilderTest.java
@@ -1,0 +1,20 @@
+package org.hl7.fhir.igtools.web;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class PackageRegistryBuilderTest {
+	@Test
+	public void testThrowsIllegalArgumentWhenPathMissing() throws IOException {
+		IllegalArgumentException thrown =  Assertions.assertThrows(IllegalArgumentException.class, () -> { PackageRegistryBuilder packageRegistryBuilder = new PackageRegistryBuilder("src/test/resources/package-registry/missing-path/");
+
+		packageRegistryBuilder.update("dummyPath",null ); });
+
+		System.out.println(thrown);
+	}
+}

--- a/org.hl7.fhir.publisher.core/src/test/resources/package-registry/missing-path/package-registry.json
+++ b/org.hl7.fhir.publisher.core/src/test/resources/package-registry/missing-path/package-registry.json
@@ -1,0 +1,22 @@
+{
+  "packages" : [
+    {
+      "package-id" : "my.package.term",
+      "title" : "MyPackageTerm",
+      "canonical" : "http://example.org/term",
+      "category" : "Terminology",
+      "ci-build" : "http://build.fhir.org/ig/myorg/my-term/",
+      "version-count" : 2,
+      "latest" : {
+        "version" : "1.1.0",
+        "date" : "2023-07-10",
+        "path" : "http://example.org/term/1.1.0"
+      },
+      "milestone" : {
+        "version" : "1.1.0",
+        "date" : "2023-07-10",
+        "path" : "http://example.org/term/1.1.0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
If an entry in package-registry.json is missing a path entry, throw an exception with a meaninful message instead of a  NullPointer.