### PR TITLE
Updated CQL translator version to 3.3.2

### DIFF
--- a/org.hl7.fhir.publisher.core/pom.xml
+++ b/org.hl7.fhir.publisher.core/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <graalvm.version>22.3.3</graalvm.version>
         <jackson_version>2.14.0</jackson_version>
-        <info_cqframework_version>1.5.12</info_cqframework_version>
+        <info_cqframework_version>3.3.2</info_cqframework_version>
     </properties>
 
     <dependencies>
@@ -35,16 +35,27 @@
             <artifactId>model</artifactId>
             <version>${info_cqframework_version}</version>
             <exclusions>
+                <!-- not sure this is necessary, I don't think this is a dependency of this package in the new version -->
                 <!-- exclude this in favor of 1.9.4 for security reasons -->
-                <exclusion>
+                <!--exclusion>
                     <groupId>commons-beanutils</groupId>
                     <artifactId>commons-beanutils</artifactId>
-                </exclusion>
+                </exclusion-->
             </exclusions>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
+            <artifactId>model-jaxb</artifactId>
+            <version>${info_cqframework_version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cqframework</groupId>
             <artifactId>elm</artifactId>
+            <version>${info_cqframework_version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cqframework</groupId>
+            <artifactId>elm-jaxb</artifactId>
             <version>${info_cqframework_version}</version>
         </dependency>
         <dependency>
@@ -68,7 +79,8 @@
             <version>1.9.4</version>
         </dependency>
         <!-- JAXB-API, used by CQL-to-ELM translator, but no longer loaded by default -->
-        <dependency>
+        <!-- Latest version of translator puts these dependencies in the model-jaxb and elm-jaxb modules -->
+        <!--dependency>
             <groupId>com.sun.xml.bind</groupId>
             <artifactId>jaxb-impl</artifactId>
             <version>2.4.0-b180830.0438</version>
@@ -87,7 +99,7 @@
             <groupId>com.sun.activation</groupId>
             <artifactId>javax.activation</artifactId>
             <version>1.2.0</version>
-        </dependency>
+        </dependency-->
         <!-- Jackson FasterXML -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This PR updates the CqlSubsystem to use the latest release of the CQL-to-ELM translator, version 3.3.2. This update was tested with the sample-ig and sample-content-ig implementation guides and confirmed that it functions correctly. This update addresses issues with resolving references to FHIRHelpers and FHIR ModelInfo, as well as some improvements to the output of the Library refresh. Note that this update does not make use of the DataRequirementsProcessor since that would require introducing a dependency on the elm-fhir package from the translator.