### PR TITLE
Prevent references going through Simplifier.resolve() 

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/SpecMapManager.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/SpecMapManager.java
@@ -183,7 +183,11 @@ public class SpecMapManager {
     }
     if (special != null) {
       switch (special) {
-      case Simplifier: return "https://simplifier.net/resolve?scope="+pi.name()+"@"+pi.version()+"&canonical="+url;
+      case Simplifier: if (url.contains("fhir.philips.com")) {
+          return url;
+        } else {
+          return "https://simplifier.net/resolve?scope="+pi.name()+"@"+pi.version()+"&canonical="+url;
+      }
       case PhinVads:  
         try {
           if (url.startsWith(base)) {


### PR DESCRIPTION
IG-Publisher manipulates found references, which exist in npm-packages.
These references are replaced by the Simplifier.resolve() function, except for some exceptions, as can be seen here
- [Select PackageType](https://github.com/cdejonge/fhir-ig-publisher/blob/master/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/SpecMapManager.java#L418C24-L418C24)
- [Act on PackageType](https://github.com/cdejonge/fhir-ig-publisher/blob/master/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/SpecMapManager.java#L170C24-L170C24)

We as Philips want our (canonical) url's to be left untouched.
We have information about the npm-package available in which `license` is an optional element.
> license - optional. Follow the [[spdx naming convention](https://spdx.org/licenses/)]

Maybe it is an option to use this information, if available.