### PR TITLE
When autoloading document Bundles, read title from Composition

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -183,7 +183,6 @@ import org.hl7.fhir.r5.model.CodeSystem.ConceptDefinitionComponent;
 import org.hl7.fhir.r5.model.CodeType;
 import org.hl7.fhir.r5.model.CodeableConcept;
 import org.hl7.fhir.r5.model.Coding;
-import org.hl7.fhir.r5.model.Composition;
 import org.hl7.fhir.r5.model.ConceptMap;
 import org.hl7.fhir.r5.model.ConceptMap.ConceptMapGroupComponent;
 import org.hl7.fhir.r5.model.Constants;
@@ -4775,18 +4774,13 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
               } else if (!rg.hasName()) {
                 if (r.getElement().hasChild("title")) {
                   rg.setName(r.getElement().getChildValue("title"));
-                } else if (r.getResource() instanceof Bundle) {
+                } else if ("Bundle".equals(r.getElement().getName())) {
                   // If the resource is a document Bundle, get the title from the Composition
-                  Bundle bundle = (Bundle) r.getResource();
-                  if (BundleType.DOCUMENT == bundle.getType()) {
-                    List<BundleEntryComponent> entryList = bundle.getEntry();
-                    if (entryList != null && !entryList.isEmpty()) {
-                      BundleEntryComponent entryComponent = entryList.get(0);
-                      Resource entryResource = entryComponent.getResource();
-                      if (entryResource instanceof Composition) {
-                        Composition composition = (Composition) entryResource;
-                        rg.setName(composition.getTitle() + " (Bundle)");
-                      }
+                  List<Element> entryList = r.getElement().getChildren("entry");
+                  if (entryList != null && !entryList.isEmpty()) {
+                    Element resource = entryList.get(0).getNamedChild("resource");
+                    if (resource != null) {
+                      rg.setName(resource.getChildValue("title") + " (Bundle)");
                     }
                   }
                 }

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -183,6 +183,7 @@ import org.hl7.fhir.r5.model.CodeSystem.ConceptDefinitionComponent;
 import org.hl7.fhir.r5.model.CodeType;
 import org.hl7.fhir.r5.model.CodeableConcept;
 import org.hl7.fhir.r5.model.Coding;
+import org.hl7.fhir.r5.model.Composition;
 import org.hl7.fhir.r5.model.ConceptMap;
 import org.hl7.fhir.r5.model.ConceptMap.ConceptMapGroupComponent;
 import org.hl7.fhir.r5.model.Constants;
@@ -4773,7 +4774,21 @@ public class Publisher implements IWorkerContext.ILoggingService, IReferenceReso
                 rg.setName(r.getElement().getExtensionValue(ToolingExtensions.EXT_ARTIFACT_NAME).primitiveValue());                 
               } else if (!rg.hasName()) {
                 if (r.getElement().hasChild("title")) {
-                  rg.setName(r.getElement().getChildValue("title"));                
+                  rg.setName(r.getElement().getChildValue("title"));
+                } else if (r.getResource() instanceof Bundle) {
+                  // If the resource is a document Bundle, get the title from the Composition
+                  Bundle bundle = (Bundle) r.getResource();
+                  if (BundleType.DOCUMENT == bundle.getType()) {
+                    List<BundleEntryComponent> entryList = bundle.getEntry();
+                    if (entryList != null && !entryList.isEmpty()) {
+                      BundleEntryComponent entryComponent = entryList.get(0);
+                      Resource entryResource = entryComponent.getResource();
+                      if (entryResource instanceof Composition) {
+                        Composition composition = (Composition) entryResource;
+                        rg.setName(composition.getTitle() + " (Bundle)");
+                      }
+                    }
+                  }
                 }
               }
               if (r.getElement().hasExtension(ToolingExtensions.EXT_RESOURCE_DESC)) {


### PR DESCRIPTION
Support autoload of some Bundles. If the Bundle is a document, use the title from the Composition as the resource title in the IG.
This does not make a difference for any other resource type and is a better alternative to not having a title at all.