### PR TITLE
FIX: The eslint text file does not contain all the error's, warnings and informationals.

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/ValidationPresenter.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/ValidationPresenter.java
@@ -431,6 +431,21 @@ public class ValidationPresenter extends TranslatingUtilities implements Compara
     StringBuilder b = new StringBuilder();
     files = sorted(files);
 
+    b.append(title + "\n");
+    b.append("=========================================");
+    b.append("\n\n");
+
+    for (ValidationMessage vm : linkErrors) {
+        String eslintSeverity = vm.getLevel().getDisplay();
+        if (eslintSeverity.equals("Information"))
+          eslintSeverity = "Info";
+
+        if (eslintSeverity.equals("Fatal"))
+          eslintSeverity = "Error";
+
+      b.append("Generic: line 0, col 0, " + eslintSeverity + " - " + vm.getMessage() + " (" + vm.getType() + ")" + "\n");
+    }
+
     for (FetchedFile f : files) {
       for (ValidationMessage vm : filterMessages(f.getErrors(), false, filteredMessages)) {
         String eslintSeverity = vm.getLevel().getDisplay();
@@ -453,8 +468,9 @@ public class ValidationPresenter extends TranslatingUtilities implements Compara
     }
 
     b.append("\n");
-    b.append(genHeaderTxt(title, err, warn, info));
-    
+    b.append("err = " + err + ", warn = " + warn + ", info = " + info + "\n");
+    b.append("IG Publisher Version: " + toolsVersion);
+
     TextFile.stringToFile(b.toString(), Utilities.changeFileExt(path, "-eslintcompact.txt"));
   }
 


### PR DESCRIPTION
The generation of the qa-eslintcompact.txt does not contain all the errors, warnings and informationals that are generated.
The ones that are called "linkerrors" were not present in the output.

We use this file to fill the problem window of visual code so that the user can just click on an error and is presented with the correct file and location automatically.

This pr completes this eslintcompact with that addtional information so that it is complete and contentwise identical to the other qa outputs. Now the total number of errors, warnings and informationals is correct with the summary given.
