### PR TITLE
The button tag is not auto-closing

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/StructureDefinitionRenderer.java
@@ -796,7 +796,7 @@ public class StructureDefinitionRenderer extends CanonicalRenderer {
       b.append(new XhtmlComposer(true, true).compose(x));
     }
     if (tx.hasValueSet()) { 
-      b.append("<div><code>"+Utilities.escapeXml(tx.getValueSet())+"</code><button title=\"Click to copy URL\" class=\"btn-copy\" data-clipboard-text=\""+Utilities.escapeXml(tx.getValueSet())+"\"/></div>");
+      b.append("<div><code>"+Utilities.escapeXml(tx.getValueSet())+"</code><button title=\"Click to copy URL\" class=\"btn-copy\" data-clipboard-text=\""+Utilities.escapeXml(tx.getValueSet())+"\"></button></div>");
       if (link != null) {
         if (Utilities.isAbsoluteUrlLinkable(link)) {
           b.append("<div>from <a href=\""+Utilities.escapeXml(link)+"\">"+Utilities.escapeXml(link)+"</a></div>");  


### PR DESCRIPTION
As per https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#technical_summary:

> Tag omission:	None, both the starting and ending tag are mandatory.

Does not fix #848 (yet), because the HTML is parsed and re-rendered wrongly by `XhtmlComposer`. Another patch in core is needed: https://github.com/hapifhir/org.hl7.fhir.core/pull/1553