### PR TITLE
Fix "path-data" missing folder error

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -2760,8 +2760,12 @@ public class Publisher implements ILoggingService, IReferenceResolver, IValidati
       case "path-test":     
         testDirs.add(Utilities.path(rootDir, p.getValue()));
         break;
-      case "path-data":     
-        dataDirs.add(Utilities.path(rootDir, p.getValue()));
+      case "path-data":
+        try {
+          dataDirs.add(Utilities.path(rootDir, p.getValue()));
+        } catch (Exception e) {
+          throw new Exception("Error adding path-data directory: " + p.getValue(), e);
+        }
         break;
       case "copyrightyear":     
         copyrightYear = p.getValue();


### PR DESCRIPTION
In CI env I was getting

```
Publishing Content Failed: Cannot read the array length because "<local3>" is null                   (00:00.105 / 02:34.889, 1Gb)
                                                                                                     (00:00.000 / 02:34.889, 1Gb)
Use -? to get command line help                                                                      (00:00.000 / 02:34.889, 1Gb)
                                                                                                     (00:00.000 / 02:34.889, 1Gb)
Stack Dump (for debugging):                                                                          (00:00.000 / 02:34.889, 1Gb)
java.lang.NullPointerException: Cannot read the array length because "<local3>" is null
	at org.hl7.fhir.igtools.publisher.Publisher.copyData(Publisher.java:7648)
	at org.hl7.fhir.igtools.publisher.Publisher.generate(Publisher.java:7423)
	at org.hl7.fhir.igtools.publisher.Publisher.createIg(Publisher.java:1166)
	at org.hl7.fhir.igtools.publisher.Publisher.execute(Publisher.java:994)
	at org.hl7.fhir.igtools.publisher.Publisher.main(Publisher.java:12543)
```

when I hadn't added my `path-data` folder to git.