### PR TITLE
Add sqlToData templating

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -10623,27 +10623,21 @@ public class Publisher implements ILoggingService, IReferenceResolver, IValidati
 
   private String processSQLData(DBBuilder db, String src, FetchedFile f) throws FHIRException, IOException {
     long start = System.currentTimeMillis();
-    
+
     if (db == null) {
         return "<span style=\"color: maroon\">No SQL this build</span>";
     }
-    
-    String[] parts = src.trim().split("\s+", 2);
-    String fileName = parts[0];
-    String sql = parts[1];
-    
+
+    String[] parts = src.trim().split("\\s+", 3);
+    String fileName = parts[1];
+    String sql = parts[2];
+
     try {
         String json = db.executeQueryToJson(sql);
-        String outputPath = Utilities.path(f.getTempDir(), "_data", fileName + ".json");
-        TextFile.stringToFile(json, outputPath, false);
-        time(start);
+        String outputPath = Utilities.path(tempDir, "_data", fileName + ".json");
+        TextFile.stringToFile(json, outputPath);
         return "{% assign " + fileName + " = site.data." + fileName + " %}";
     } catch (Exception e) {
-        db.errors.add(e.getMessage());
-        if (db.debug) {
-            e.printStackTrace();
-        }
-        time(start);
         return "<span style=\"color: maroon\">Error processing SQL: " + Utilities.escapeXml(e.getMessage()) + "</span>";
     }
   }

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -10522,8 +10522,8 @@ public class Publisher implements ILoggingService, IReferenceResolver, IValidati
         String sfx = src.substring(i + 2);
         String sql = src.substring(0, i);
 
-        if (sql.trim().startsWith("sqlToData")) {
-          src = pfx + processSQLData(db, sql, f) + sfx;
+        if (sql.trim().startsWith("ToData ")) {
+          src = pfx + processSQLData(db, sql.substring(7), f) + sfx;
         } else {
           src = pfx + processSQLCommand(db, sql, f) + sfx;
         }
@@ -10628,9 +10628,9 @@ public class Publisher implements ILoggingService, IReferenceResolver, IValidati
         return "<span style=\"color: maroon\">No SQL this build</span>";
     }
 
-    String[] parts = src.trim().split("\\s+", 3);
-    String fileName = parts[1];
-    String sql = parts[2];
+    String[] parts = src.trim().split("\\s+", 2);
+    String fileName = parts[0];
+    String sql = parts[1];
 
     try {
         String json = db.executeQueryToJson(sql);

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -10514,14 +10514,19 @@ public class Publisher implements ILoggingService, IReferenceResolver, IValidati
     try {
       String src = new String(content);
       boolean changed = false;
-      while (db != null &&  src.contains("{% sql")) {
+      while (db != null && src.contains("{% sql")) {
         int i = src.indexOf("{% sql");
         String pfx = src.substring(0, i);
-        src = src.substring(i+6);
+        src = src.substring(i + 6);
         i = src.indexOf("%}");
-        String sfx = src.substring(i+2);
-        src = src.substring(0, i);
-        src = pfx+processSQlCommand(db, src, f)+sfx;
+        String sfx = src.substring(i + 2);
+        String sql = src.substring(0, i);
+
+        if (sql.trim().startsWith("sqlToData")) {
+          src = pfx + processSQLData(db, sql, f) + sfx;
+        } else {
+          src = pfx + processSQLCommand(db, sql, f) + sfx;
+        }
         changed = true;
       }
       while (src.contains("[[[")) {
@@ -10589,7 +10594,7 @@ public class Publisher implements ILoggingService, IReferenceResolver, IValidati
   private Map<String, FragmentUseRecord> fragmentUses = new HashMap<>();
   private boolean trackFragments = false;
   
-  private String processSQlCommand(DBBuilder db, String src, FetchedFile f) throws FHIRException, IOException {
+  private String processSQLCommand(DBBuilder db, String src, FetchedFile f) throws FHIRException, IOException {
     long start = System.currentTimeMillis();
     String output = db == null ? "<span style=\"color: maroon\">No SQL this build</span>" : db.processSQL(src);
     int i = sqlIndex++;
@@ -10613,6 +10618,33 @@ public class Publisher implements ILoggingService, IReferenceResolver, IValidati
 
     public String getValue() {
       return value;
+    }
+  }
+
+  private String processSQLData(DBBuilder db, String src, FetchedFile f) throws FHIRException, IOException {
+    long start = System.currentTimeMillis();
+    
+    if (db == null) {
+        return "<span style=\"color: maroon\">No SQL this build</span>";
+    }
+    
+    String[] parts = src.trim().split("\s+", 2);
+    String fileName = parts[0];
+    String sql = parts[1];
+    
+    try {
+        String json = db.executeQueryToJson(sql);
+        String outputPath = Utilities.path(f.getTempDir(), "_data", fileName + ".json");
+        TextFile.stringToFile(json, outputPath, false);
+        time(start);
+        return "{% assign " + fileName + " = site.data." + fileName + " %}";
+    } catch (Exception e) {
+        db.errors.add(e.getMessage());
+        if (db.debug) {
+            e.printStackTrace();
+        }
+        time(start);
+        return "<span style=\"color: maroon\">Error processing SQL: " + Utilities.escapeXml(e.getMessage()) + "</span>";
     }
   }
 

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/DBBuilder.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/DBBuilder.java
@@ -648,23 +648,23 @@ public class DBBuilder {
     if (con == null) {
       throw new IllegalStateException("No database connection available.");
     }
-    
+
     if (sql == null) {
       throw new IllegalArgumentException("Param sql cannot be null.");
     }
-    
+
     Statement stmt = con.createStatement();
     ResultSet rs = stmt.executeQuery(sql);
     ResultSetMetaData rsmd = rs.getMetaData();
-    
+
     JsonArray jsonArray = new JsonArray();
-    
+
     while (rs.next()) {
       JsonObject jsonObject = new JsonObject();
       for (int i = 1; i <= rsmd.getColumnCount(); i++) {
         String colName = rsmd.getColumnName(i);
         Object value = rs.getObject(i);
-        
+
         if (value == null) {
           jsonObject.add(colName, new JsonNull());
         } else if (value instanceof String) {
@@ -679,7 +679,7 @@ public class DBBuilder {
       }
       jsonArray.add(jsonObject);
     }
-    
+
     return jsonArray.toString();
   }
 


### PR DESCRIPTION
Add sqlToData templating

## Example usage:  

https://github.com/argonautproject/cgm/blob/a5b65a14639532e595702ed225642c95213e15d7/input/pagecontent/index.md?plain=1#L175-L214

```md
#### Overview of LOINC Mappings

{% sqlToData mappingCodes SELECT
  c.code as "Temporary Code",
  CASE
    WHEN cm.TargetCode IS NOT NULL THEN cm.TargetCode
    ELSE 'No LOINC Available'
  END as "LOINC Code"
FROM
  Concepts c
JOIN Resources r ON c.ResourceKey = r.key
LEFT JOIN ConceptMappings cm ON c.code = cm.SourceCode AND cm.SourceSystem LIKE '%cgm-summary-codes-temporary'
WHERE
  r.json->>'$.url' LIKE '%temporary'
%}

{% assign mappedCodes = 0 %}
{% assign unmappedCodes = 0 %}

{% for row in mappingCodes %}
  {% if row["LOINC Code"] == "No LOINC Available" %}
    {% assign unmappedCodes = unmappedCodes | plus: 1 %}
  {% else %}
    {% assign mappedCodes = mappedCodes | plus: 1 %}
  {% endif %}
{% endfor %}

##### Mapping Overview

- Total Concepts Required: {{ mappingCodes.size }}
  - **Mapped**: {{ mappedCodes }}
  - **Unmapped**: {{ unmappedCodes }}

##### Mapping Table

| Temporary Code | LOINC Code |
|----------------|------------|
{% for row in mappingCodes -%}
| {{ row["Temporary Code"] }} | {{ row["LOINC Code"] }} |
{% endfor %}
```

## Example output
![image](https://github.com/HL7/fhir-ig-publisher/assets/313089/eab03d68-2760-47b2-94eb-63d597e5baea)
