### PR TITLE
Tweaks to the codepaths related to the cross version IG pre-processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,30 @@ This project is maintained by [Grahame Grieve][Link-grahameGithub] and [Lloyd Mc
 [Badge-AzureReleasePipeline]: https://dev.azure.com/fhir-pipelines/ig-publisher/_apis/build/status/Release%20Branch%20Pipeline?branchName=master
 [Badge-SonatypeReleases]: https://img.shields.io/nexus/r/https/oss.sonatype.org/org.hl7.fhir.publisher/org.hl7.fhir.publisher.svg "Sonatype Releases"
 [Badge-SonatypeSnapshots]: https://img.shields.io/nexus/s/https/oss.sonatype.org/org.hl7.fhir.publisher/org.hl7.fhir.publisher.svg "Sonatype Snapshots"
+
+## Debugging this project with VS-Code
+Setup a launch.json file in the .vscode folder with the following content:
+``` json
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Publisher",
+            "request": "launch",
+            "mainClass": "org.hl7.fhir.igtools.publisher.Publisher",
+            "projectName": "org.hl7.fhir.publisher.core",
+            "cwd": "c:/git/hl7/utg",
+            "args": [
+                "-ig", ".",
+                "-tx", "http://tx.fhir.org/r4"
+            ]
+        }
+    ]
+}
+```
+Update the path to the location of the IG that you want to debug the generation of
+and click debug in VS-Code.

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/modules/CrossVersionModule.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/modules/CrossVersionModule.java
@@ -111,6 +111,7 @@ public class CrossVersionModule implements IPublisherModule, ProfileKnowledgePro
         
         cu = new ContextUtilities(engine.getVdr5());
         engine.logProgress("Generating fragments");
+        Utilities.createDirectory(Utilities.path(path, "temp", "xver-qa"));
         genChainsHtml(path, "cross-version-chains-all", false, false);
         genChainsHtml(path, "cross-version-chains-valid", true, false);
         genChainsHtml(path, "cross-version-chains-min", true, true);

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/modules/xver/XVerAnalysisEngine.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/modules/xver/XVerAnalysisEngine.java
@@ -1515,6 +1515,11 @@ public class XVerAnalysisEngine implements IMultiMapRendererAdvisor {
       String verMM = VersionUtilities.getMajMin(type);
       String ver = VersionUtilities.getNameForVersion(verMM).toLowerCase();
       IWorkerContext vd = versions.get(ver);
+      if (vd == null) {
+        qaMsg("Type "+ type +" has unknown version `"+ver+"` in map "+map.getUrl()+" sources (uses)", true);
+        ok = false;
+        return false;
+      }
       StructureDefinition sd = vd.fetchTypeDefinition(tn);
       if (sd == null) {
         qaMsg("Unknown type "+type+" in map "+map.getUrl(), true);


### PR DESCRIPTION
Specifically:
* remove the hard-coded path to `/Users/grahamegrieve/work/fhir-cross-version` and pass the path via parameters
* ensure the `temp/xver-qa` path exists before trying to read/write to it