### PR TITLE
Fix issues with UTF-8 2-byte characters

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FSHRunner.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FSHRunner.java
@@ -174,9 +174,9 @@ public class FSHRunner {
 
         @Override
         public void write(int b) throws IOException {
-            try {
-                this.buffer.write(b);}
-            catch (Exception e) {
+            if (b >= -128 && b <= 127) {
+                this.buffer.write(b);
+            } else {
                 this.buffer.write('?');
             }
             if (b == 10) { // eoln

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FSHRunner.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FSHRunner.java
@@ -177,7 +177,7 @@ public class FSHRunner {
             try {
                 this.buffer.write(b);}
             catch (Exception e) {
-                this.buffer.write('X');
+                this.buffer.write('?');
             }
             if (b == 10) { // eoln
                 final String s = this.getBufferString();

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/FSHRunnerTest.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/FSHRunnerTest.java
@@ -3,10 +3,12 @@ package org.hl7.fhir.igtools.publisher;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -21,14 +23,30 @@ class FSHRunnerTest {
 
         final StringBuilder stringBuilder = new StringBuilder(512);
         final FSHRunner.MySushiHandler mySushiHandler = getMySushiHandler(stringBuilder);
-        for (final int codePoint : "1234".codePoints().toArray()) {
-            mySushiHandler.write(codePoint);
+        for (final int myByte : "1234".getBytes(StandardCharsets.UTF_8)) {
+            mySushiHandler.write(myByte);
         }
         assertEquals("1234", mySushiHandler.getBufferString());
         assertEquals(0, stringBuilder.length());
         mySushiHandler.write(10); // EOL
         assertEquals("", mySushiHandler.getBufferString());
         assertEquals("Sushi: 1234", stringBuilder.toString());
+    }
+
+    @Test
+    @DisplayName("Test MySushiHandler with UTF-8 two-byte characters")
+    void testMySushiHandlerTwoByte() throws IOException {
+
+        final StringBuilder stringBuilder = new StringBuilder(512);
+        final FSHRunner.MySushiHandler mySushiHandler = getMySushiHandler(stringBuilder);
+        for (final int myByte : "МЗРФ".getBytes(StandardCharsets.UTF_8)) {
+            mySushiHandler.write(myByte);
+        }
+        assertEquals("МЗРФ", mySushiHandler.getBufferString());
+        assertEquals(0, stringBuilder.length());
+        mySushiHandler.write(10); // EOL
+        assertEquals("", mySushiHandler.getBufferString());
+        assertEquals("Sushi: МЗРФ", stringBuilder.toString());
     }
 
     @Nonnull


### PR DESCRIPTION
The previous implementation of MySushiHandler used a StringBuilder, which was trying to append the first byte value of a two-byte UTF-8 character, resulting in a silent failure.

Fix uses a ByteArrayOutputStream and also treats invalid characters b replacing them with '?'.