### PR TITLE
Fix nullpointer in HistoryGenerator

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/HistoryGenerator.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/HistoryGenerator.java
@@ -163,7 +163,7 @@ public class HistoryGenerator {
     }
     List<Element> entries = resource.getChildrenByName("entry");
     for (Element be : entries) {
-      if (!"Provenance".equals(be.getNamedChild("resource").fhirType())) {
+      if (!be.hasChild("resource") || !"Provenance".equals(be.getNamedChild("resource").fhirType())) {
         return false;
       }
     }


### PR DESCRIPTION
In the ITI.MHD IG, the following fsh generated resource (ITI.MHD/fsh-generated/resources/Bundle-ex-response-comprehensiveProvideDocumentBundleComplete.json) causes a NullPointer exception when processed by HistoryGenerator.

```json
{
  "resourceType": "Bundle",
  "id": "ex-response-comprehensiveProvideDocumentBundleComplete",
  "meta": {
    "security": [
      {
        "code": "HTEST",
        "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason"
      }
    ],
    "profile": [
      "https://profiles.ihe.net/ITI/MHD/StructureDefinition/IHE.MHD.ProvideDocumentBundleResponse"
    ]
  },
  "type": "transaction-response",
  "link": [
    {
      "relation": "self",
      "url": "http://example.com/fhir"
    }
  ],
  "entry": [
    {
      "response": {
        "status": "201 Created",
        "location": "List/501",
        "lastModified": "2020-10-05T11:56:15.094+00:00"
      }
    },
    {
      "response": {
        "status": "201 Created",
        "location": "List/502",
        "lastModified": "2020-10-05T11:56:15.095+00:00"
      }
    },
    {
      "response": {
        "status": "201 Created",
        "location": "DocumentReference/501",
        "lastModified": "2020-10-05T11:56:15.096+00:00"
      }
    },
    {
      "response": {
        "status": "201 Created",
        "location": "Binary/501",
        "lastModified": "2020-10-05T11:56:15.097+00:00"
      }
    }
  ]
}
```

The response entries do not contain a resource child, and cause null pointers.
