### PR TITLE
Reader friendly dependency table

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -8865,6 +8865,8 @@ private String fixPackageReference(String dep) {
     start = System.currentTimeMillis();
     trackedFragment("3", "dependency-table-short", depr.render(publishedIg, false, false, false), otherFilesRun, start, "dependency-table-short", "Cross");
     start = System.currentTimeMillis();
+    trackedFragment("3", "dependency-table-nontech", depr.renderNonTech(publishedIg), otherFilesRun, start, "dependency-table-nontech", "Cross");
+    start = System.currentTimeMillis();
     trackedFragment("4", "globals-table", depr.renderGlobals(), otherFilesRun, start, "globals-table", "Cross");
 
     // now, list the profiles - all the profiles

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -11251,7 +11251,7 @@ private String fixPackageReference(String dep) {
     String format = (secondSpace == -1) ? arguments.substring(firstSpace) : arguments.substring(firstSpace, secondSpace);
     format = format.trim().toLowerCase();
     String filters = (secondSpace == -1) ? "" : arguments.substring(secondSpace).trim();
-    Pattern refPattern = Pattern.compile("^([A-Z][a-z]+)+\\/([A-Za-z0-9\\-\\.]{1,64})$");
+    Pattern refPattern = Pattern.compile("^([A-Za-z]+)\\/([A-Za-z0-9\\-\\.]{1,64})$");
     Matcher refMatcher = refPattern.matcher(reference);
     if (!refMatcher.find())
       throw new FHIRException("Fragment syntax error: Referenced instance must be expressed as [ResourceType]/[id].  Found " + reference + " in file " + f.getName());

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/DependencyRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/DependencyRenderer.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_14_50;
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_30_50;
 import org.hl7.fhir.convertors.factory.VersionConvertorFactory_40_50;
@@ -113,6 +115,7 @@ public class DependencyRenderer {
   private MarkDownProcessor mdEngine;
   private RenderingContext rc;
   private List<SpecMapManager> specMaps;
+  private Map<String, PackageInfo> packagesByName;
   
   public DependencyRenderer(BasePackageCacheManager pcm, String dstFolder, String npmName, TemplateManager templateManager,
       List<DependencyAnalyser.ArtifactDependency> dependencies, IWorkerContext context, MarkDownProcessor mdEngine, RenderingContext rc, List<SpecMapManager> specMaps) {
@@ -128,10 +131,153 @@ public class DependencyRenderer {
     this.specMaps = specMaps;
   }
 
+  private class PackageVersionInfo {
+    private NpmPackage p;
+    @Getter
+    @Setter
+    private boolean direct;
+    @Getter
+    @Setter
+    private String reason;
+    private String parent;
+    public PackageVersionInfo(NpmPackage p, boolean direct, String reason, String parent) {
+      this.p = p;
+      this.direct = direct;
+      this.reason = reason;
+      this.parent = parent;
+    }
+
+    public String getReason() {
+      if (reason!=null)
+        return reason;
+      else
+        return "Imported by " + parent + " (and potentially others)";
+    }
+  }
+
+  private class PackageInfo {
+    private NpmPackage p;
+    private boolean direct;
+    private Map<String, PackageVersionInfo> versions = new HashMap<String, PackageVersionInfo>();
+    public PackageInfo(NpmPackage p, String reason, boolean direct, String parent) {
+      this.p = p;
+      this.direct = direct;
+      versions = new HashMap<String, PackageVersionInfo>();
+      PackageVersionInfo v = new PackageVersionInfo(p, direct, reason, parent);
+      versions.put(p.version(), v);
+    }
+
+    // Returns true if the version wasn't already present
+    protected boolean addVersion (NpmPackage p, String reason, boolean direct, String parent) {
+      if (versions.containsKey(p.version())) {
+        if (direct) {
+          this.direct = direct;
+          PackageVersionInfo v = versions.get(p.version());
+          v.setDirect(direct);
+          v.setReason(reason);
+        }
+        return false;
+      }
+      this.direct = this.direct || direct;
+      PackageVersionInfo v = new PackageVersionInfo(p, direct, reason, parent);
+      versions.put(p.version(), v);
+      return true;
+    }
+  }
+
+  public String renderNonTech(ImplementationGuide ig) throws FHIRException, IOException {
+    packagesByName = new HashMap<String, PackageInfo>();
+    for (ImplementationGuideDependsOnComponent d : ig.getDependsOn()) {
+      NpmPackage p = resolve(d);
+      boolean dloaded = isLoaded(p);
+      if (dloaded) {
+        addPackage(p, d.hasReason() ? d.getReason() : ToolingExtensions.readStringExtension(d, ToolingExtensions.EXT_IGDEP_COMMENT), true);
+      }
+    }
+
+    if (packagesByName.isEmpty())
+      return "";
+    else {
+      StringBuilder b = new StringBuilder();
+      b.append("<table style=\"border: 0px #F0F0F0 solid;\"><thead><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><th><b>Implementation Guide</b></th><th><b>Version(s)</b></th><th><b>Reason</b></th></tr></thead><tbody>");
+      List<String> names = new ArrayList<String>(packagesByName.keySet());
+      Collections.sort(names);
+      int lineCount = 1;
+      for (String name: names) {
+        PackageInfo info = packagesByName.get(name);
+        String newRow = "<tr style=\"font-size: 11px; font-family: verdana; vertical-align: top; background-color: " + ((lineCount % 2 == 0) ? "#F7F7F7" : "white") + "\"><td";
+        b.append(newRow);
+        if (info.versions.size()!=1)
+          b.append(" rowspan=\"" + info.versions.size() + "\"");
+        b.append("><span class=\"copy-text\" title=\"canonical: " + info.p.canonical() + "\"><a style=\"font-size: 11px; font-family: verdana; font-weight:" + (info.direct ? "bold" : "normal") + "\"");
+        b.append(" href=\"" + info.p.url() + "\">" + Utilities.escapeXml(name) + "</a><button class=\"btn-copy\" title=\"Click to copy URL\" data-clipboard-text=\"" + info.p.canonical() + "\"/></span></td><td>");
+        boolean first = true;
+        List<String> versions = new ArrayList<String>(info.versions.keySet());
+        Collections.sort(versions, Collections.reverseOrder());
+        for (String version: versions) {
+          PackageVersionInfo verInfo = info.versions.get(version);
+          if (!first)
+            b.append(newRow + ">");
+          b.append("<span class=\"copy-text\" title=\"package: " + verInfo.p.id() + "#" + version + "\"><a style=\"font-size: 11px; font-family: verdana; font-weight: " + (verInfo.direct ? "bold" : "normal") + "\"");
+          b.append(" href=\"https://simplifier.net/packages/" + info.p.name() + "/" + version + "\">" + version + "</a><button class=\"btn-copy\" title=\"Click to copy package\" data-clipboard-text=\"" + verInfo.p.id() + "#" + version + "\"/></span>");
+          b.append("</td><td" + (verInfo.direct ? "" : " style=\"font-style: italic;\"") + ">" + Utilities.escapeXml(verInfo.getReason()) + "</td></tr>");
+
+          first = false;
+        }
+        lineCount++;
+        first = true;
+      }
+      b.append("</tbody></table>");
+
+      return b.toString();
+    }
+  }
+
+  private void addPackage(NpmPackage p, String reason, boolean direct) {
+    addPackage(p, reason, direct, null);
+  }
+  private void addPackage(NpmPackage p, String reason, boolean direct, String parent) {
+    PackageInfo packageInfo;
+    String title;
+    if (p.getNpm().has("title"))
+      title = p.title();
+    else if (p.name().endsWith(".vsac"))
+      title = "Value Set Authority Center (VSAC)";
+    else if (p.name().endsWith(".phinvads"))
+      title = "Public Health Information Network Vocabulary Access and Distribution System (PHIN VADS)";
+    else
+      title = p.name();
+    if (title.contains("Wrapper)"))
+      title = title.substring(0, title.indexOf("(")).trim();
+    if (title.endsWith("Implementation Guide"))
+      title = title.substring(0, title.length()-20).trim();
+    if (packagesByName.containsKey(title)) {
+      packageInfo = packagesByName.get(title);
+      if (!packageInfo.addVersion(p, reason, direct, parent))
+        return;
+    } else {
+      packageInfo = new PackageInfo(p, reason, direct, parent);
+      packagesByName.put(title, packageInfo);
+    }
+
+    for (String d: p.dependencies()) {
+      if (isLoaded(d)) {
+        String id = d.substring(0, d.indexOf("#"));
+        String version = d.substring(d.indexOf("#") + 1);
+        try {
+          NpmPackage dp = resolve(id, version);
+          addPackage(dp, null, false, title);
+        } catch (Exception e) {
+          // Do nothing - this'll be dealt with elsewhere
+        }
+      }
+    }
+  }
+
   public String render(ImplementationGuide ig, boolean QA, boolean details, boolean first) throws FHIRException, IOException {
     boolean hasDesc = false;
     for (ImplementationGuideDependsOnComponent d : ig.getDependsOn()) {
-      hasDesc = hasDesc || d.hasExtension(ToolingExtensions.EXT_IGDEP_COMMENT);
+      hasDesc = hasDesc || d.hasExtension(ToolingExtensions.EXT_IGDEP_COMMENT) || d.hasReason();
     }
     
     HierarchicalTableGenerator gen = new HierarchicalTableGenerator(rc, dstFolder, true, true, "dep");
@@ -149,7 +295,7 @@ public class DependencyRenderer {
         NpmPackage p = resolve(d);
         boolean dloaded = isLoaded(p);
         if (QA || dloaded) {
-          addPackageRow(gen, row.getSubRows(), p, d.getVersion(), realm, QA, b, ToolingExtensions.readStringExtension(d, ToolingExtensions.EXT_IGDEP_COMMENT), hasDesc, processed, listed, dloaded);
+          addPackageRow(gen, row.getSubRows(), p, d.getVersion(), realm, QA, b, d.hasReason() ? d.getReason() : ToolingExtensions.readStringExtension(d, ToolingExtensions.EXT_IGDEP_COMMENT), hasDesc, processed, listed, dloaded);
         }
       } catch (Exception e) {
         e.printStackTrace();


### PR DESCRIPTION
Introduced a new dependency table syntax that's more friendly to the average user:
- It shows all IGs, but only once.  It lists the IG name only once but shows all versions.  It hides the canonical URLs and package ids, but still makes them available via fly-over and 'click to copy' buttons.

Hoping this will overcome some people's objections to listing IG dependencies on the home page.

To see what this looks like with behavior, build this IG branch: https://github.com/HL7/davinci-crd/tree/DependencyTableDemo

![image](https://github.com/user-attachments/assets/f211dbd0-c2c1-49c4-b0a0-4b3967662a54)
