### PR TITLE
Automate testing for XMLUtils factory methods

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -28,15 +28,32 @@
         <property name="id" value="transformerFactoryNewInstance"/>
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="TransformerFactory\.newInstance\("/>
+        <property name="message"
+                  value="Usage of TransformerFactory.newInstance() is only allowed in XMLUtil.newXXEProtectedTransformerFactory(). If the location of this call in XMLUtil has changed, please modify the expected line number in org.hl7.fhir.utilities/checkstyle_suppressions.xml"
+        />
     </module>
     <module name="RegexpMultiline">
         <property name="id" value="documentBuilderFactoryNewInstance"/>
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="DocumentBuilderFactory\.newInstance\("/>
+        <property name="message"
+                  value="Usage of DocumentBuilderFactory.newInstance() is only allowed in XMLUtil.newXXEProtectedDocumentBuilderFactory(). If the location of this call in XMLUtil has changed, please modify the expected line number in org.hl7.fhir.utilities/checkstyle_suppressions.xml"
+        />
     </module>
     <module name="RegexpMultiline">
         <property name="id" value="saxParserFactoryNewInstance"/>
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="SAXParserFactory\.newInstance\("/>
+        <property name="message"
+                  value="Usage of SAXParserFactory.newInstance() is only allowed in XMLUtil.newXXEProtectedSaxParserFactory(). If the location of this call in XMLUtil has changed, please modify the expected line number in org.hl7.fhir.utilities/checkstyle_suppressions.xml"
+        />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="id" value="getXMLReader"/>
+        <property name="matchAcrossLines" value="true"/>
+        <property name="format" value="\.getXMLReader\("/>
+        <property name="message"
+                  value="Usage of SAXParserFactory.getXMLReader() is only allowed in XMLUtil.getXXEProtectedXMLReader(...). If the location of this call in XMLUtil has changed, please modify the expected line number in org.hl7.fhir.utilities/checkstyle_suppressions.xml"
+        />
     </module>
 </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -29,7 +29,7 @@
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="TransformerFactory\.newInstance\("/>
         <property name="message"
-                  value="Usage of TransformerFactory.newInstance() is only allowed in XMLUtil.newXXEProtectedTransformerFactory(). If the location of this call in XMLUtil has changed, please modify the expected line number in org.hl7.fhir.utilities/checkstyle_suppressions.xml"
+                  value="Usage of TransformerFactory.newInstance() is only allowed in XMLUtil.newXXEProtectedTransformerFactory()."
         />
     </module>
     <module name="RegexpMultiline">
@@ -37,7 +37,7 @@
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="DocumentBuilderFactory\.newInstance\("/>
         <property name="message"
-                  value="Usage of DocumentBuilderFactory.newInstance() is only allowed in XMLUtil.newXXEProtectedDocumentBuilderFactory(). If the location of this call in XMLUtil has changed, please modify the expected line number in org.hl7.fhir.utilities/checkstyle_suppressions.xml"
+                  value="Usage of DocumentBuilderFactory.newInstance() is only allowed in XMLUtil.newXXEProtectedDocumentBuilderFactory()."
         />
     </module>
     <module name="RegexpMultiline">
@@ -45,7 +45,7 @@
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="SAXParserFactory\.newInstance\("/>
         <property name="message"
-                  value="Usage of SAXParserFactory.newInstance() is only allowed in XMLUtil.newXXEProtectedSaxParserFactory(). If the location of this call in XMLUtil has changed, please modify the expected line number in org.hl7.fhir.utilities/checkstyle_suppressions.xml"
+                  value="Usage of SAXParserFactory.newInstance() is only allowed in XMLUtil.newXXEProtectedSaxParserFactory()."
         />
     </module>
     <module name="RegexpMultiline">
@@ -53,7 +53,7 @@
         <property name="matchAcrossLines" value="true"/>
         <property name="format" value="\.getXMLReader\("/>
         <property name="message"
-                  value="Usage of SAXParserFactory.getXMLReader() is only allowed in XMLUtil.getXXEProtectedXMLReader(...). If the location of this call in XMLUtil has changed, please modify the expected line number in org.hl7.fhir.utilities/checkstyle_suppressions.xml"
+                  value="Usage of SAXParserFactory.getXMLReader() is only allowed in XMLUtil.getXXEProtectedXMLReader(...)."
         />
     </module>
 </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -11,17 +11,32 @@
     <module name="TreeWalker">
         <!--
         <module name="TodoComment">-->
-            <!-- The (?i) below means Case Insensitive -->
+        <!-- The (?i) below means Case Insensitive -->
         <!--<property name="format" value="(?i)FIXME"/>
 -->
-  <module name="RegexpSinglelineJava">
-      <property name="format" value="org\.jetbrains\.annotations\.NotNull"/>
-  </module>
-  <module name="RegexpSinglelineJava">
-      <property name="format" value="org\.jetbrains\.annotations\.Nullable"/>
-  </module>
-  <module name="RegexpSinglelineJava">
-      <property name="format" value="org\.jetbrains\.annotations\.\*"/>
-  </module>
-</module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="org\.jetbrains\.annotations\.NotNull"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="org\.jetbrains\.annotations\.Nullable"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="org\.jetbrains\.annotations\.\*"/>
+        </module>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="id" value="transformerFactoryNewInstance"/>
+        <property name="matchAcrossLines" value="true"/>
+        <property name="format" value="TransformerFactory\.newInstance\("/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="id" value="documentBuilderFactoryNewInstance"/>
+        <property name="matchAcrossLines" value="true"/>
+        <property name="format" value="DocumentBuilderFactory\.newInstance\("/>
+    </module>
+    <module name="RegexpMultiline">
+        <property name="id" value="saxParserFactoryNewInstance"/>
+        <property name="matchAcrossLines" value="true"/>
+        <property name="format" value="SAXParserFactory\.newInstance\("/>
+    </module>
 </module>

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -14312,7 +14312,7 @@ private String fixPackageReference(String dep) {
   private void loadMappingSpaces(byte[] source) throws Exception {
     ByteArrayInputStream is = null;
     try {
-      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      DocumentBuilderFactory factory = XMLUtil.newXXEProtectedDocumentBuilderFactory();
       factory.setNamespaceAware(true);
       DocumentBuilder builder = factory.newDocumentBuilder();
       is = new ByteArrayInputStream(source);

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/utils/PackageReleaser.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/utils/PackageReleaser.java
@@ -840,7 +840,7 @@ public class PackageReleaser {
 
   private Document loadXml(File file) throws Exception {
     InputStream src = new FileInputStream(file);
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    DocumentBuilderFactory dbf = XMLUtil.newXXEProtectedDocumentBuilderFactory();
     DocumentBuilder db = dbf.newDocumentBuilder();
     return db.parse(src);
   }

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/utils/TemplateReleaser.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/utils/TemplateReleaser.java
@@ -601,7 +601,7 @@ public class TemplateReleaser {
 
   private Document loadXml(File file) throws Exception {
     InputStream src = new FileInputStream(file);
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    DocumentBuilderFactory dbf = XMLUtil.newXXEProtectedDocumentBuilderFactory();
     DocumentBuilder db = dbf.newDocumentBuilder();
     return db.parse(src);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
         <core_version>6.4.2-SNAPSHOT</core_version>
         <maven_surefire_version>3.0.0-M5</maven_surefire_version>
         <apache_poi_version>5.2.1</apache_poi_version>
+        <lombok_version>1.18.32</lombok_version>
         <okhttp.version>4.11.0</okhttp.version>
         <junit_jupiter_version>5.7.1</junit_jupiter_version>
         <maven.compiler.release>11</maven.compiler.release>
@@ -332,6 +333,13 @@
                     <encoding>UTF-8</encoding>
                     <fork>false</fork>
                     <debug>true</debug>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok_version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
                 <executions>
                     <!-- Replacing default-compile as it is treated specially by maven -->


### PR DESCRIPTION
There are already helper methods in place in XMLUtils to address potential XXE vulnerabilities.

This PR uses the checkstyle plugin to disallow instantiation of those various factories anywhere except where they are called in XMLUtils.