### PR TITLE
Hacky POC of fixing FHIR package transitive dependency problem

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -4239,8 +4239,23 @@ public class Publisher implements ILoggingService, IReferenceResolver, IValidati
 
   private void loadIGPackage(String name, String canonical, String packageId, String igver, NpmPackage pi, boolean loadDeps)
       throws IOException {
-    if (pi != null)
+    if (pi != null) {
       npmList.add(pi);
+      if (loadDeps) {
+        for (String dep : pi.dependencies()) {
+          if (!context.hasPackage(dep)) {
+            String fdep = fixPackageReference(dep);
+            String coreVersion = VersionUtilities.getVersionForPackage(fdep);
+            if (coreVersion != null) {
+              log("Ignore Dependency on Core FHIR " + fdep + ", from package '" + pi.name() + "#" + pi.version() + "'");
+            } else {
+              NpmPackage dpi = pcm.loadPackage(fdep);
+              npmList.add(dpi);
+            }
+          }
+        }
+      }
+    }
     logDebugMessage(LogCategory.INIT, "Load "+name+" ("+canonical+") from "+packageId+"#"+igver);
 
 


### PR DESCRIPTION
This was a problem discovered when trying to refer to dependant CQL libraries in external FHIR packages. The npm list was not including transitive dependencies.