### PR TITLE
Use BCP 47 language tag instead of Java Locale toString

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -3252,7 +3252,7 @@ public class Publisher implements ILoggingService, IReferenceResolver, IValidati
       if (sourceIg.hasJurisdiction()) {
         Locale localeFromRegion = ResourceUtilities.getLocale(sourceIg);
         if (localeFromRegion != null) {
-          sourceIg.setLanguage(localeFromRegion.toString());
+          sourceIg.setLanguage(localeFromRegion.toLanguageTag());
         } else {
           throw new Error("Unable to determine locale from jurisdiction (as requested by policy)");
         }


### PR DESCRIPTION
Java Locale toString returns the Java Constant representation of a locale instead of the correct BCP 47 language tag.