### PR TITLE
Add Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,15 @@
 # This workflow will build the Java project with Maven and peform IntelliJ smoke tests
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Smoke Tests
+name: Docker Build
 
 on:
   push:
     branches:
-      - '**'
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
   docker-build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: Build (no push)
       uses: docker/build-push-action@v6
       with:
         push: false
         tags: user/app:latest
+        build-args: |
+          BUILDKIT_CONTEXT_KEEP_GIT_DIR=true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,24 @@
+# This workflow will build the Java project with Maven and peform IntelliJ smoke tests
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Smoke Tests
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v4
+    - name: Build (no push)
+      uses: docker/build-push-action@v6
+      with:
+        push: false
+        tags: user/app:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
     - name: Checkout project
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Build (no push)
       uses: docker/build-push-action@v6
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM maven:3.6.3-jdk-11 AS build
-HEALTHCHECK CMD "java -jar /app/org.hl7.fhir.publisher.cli.jar"
+FROM maven:3.9.9-eclipse-temurin-11 AS build
 WORKDIR /build
 COPY lib ./lib
 COPY pom.xml ./pom.xml
@@ -23,11 +22,13 @@ RUN mkdir /home/$APPLICATION_USER/.fhir
 RUN chown -R $APPLICATION_USER /home/$APPLICATION_USER/.fhir
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git ruby-full build-essential zlib1g-dev && \
+    apt-get install -y --no-install-recommends git ruby-full build-essential zlib1g-dev nodejs npm && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
+    npm install -g fsh-sushi && \
     gem install jekyll
 
 USER $APPLICATION_USER
 COPY --from=build /build/org.hl7.fhir.publisher.cli/target/org.hl7.fhir.publisher.cli-*-SNAPSHOT.jar /app/org.hl7.fhir.publisher.cli.jar
+HEALTHCHECK CMD java -jar /app/org.hl7.fhir.publisher.cli.jar
 ENTRYPOINT ["java", "-jar", "/app/org.hl7.fhir.publisher.cli.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM maven:3.6.3-jdk-11 AS build
+HEALTHCHECK CMD "java -jar /app/org.hl7.fhir.publisher.cli.jar"
 WORKDIR /build
 COPY lib ./lib
 COPY pom.xml ./pom.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,17 @@ COPY . .
 RUN mvn install -Dmaven.test.skip=true
 
 FROM eclipse-temurin:11
-WORKDIR /usr/src/app
+WORKDIR /app
+
+USER root
+
+ENV APPLICATION_USER=igpublisher
+RUN adduser $APPLICATION_USER
+
+RUN chown -R $APPLICATION_USER /app
+
+RUN mkdir /home/$APPLICATION_USER/.fhir
+RUN chown -R $APPLICATION_USER /home/$APPLICATION_USER/.fhir
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git ruby-full build-essential zlib1g-dev && \
@@ -17,5 +27,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     gem install jekyll
 
-COPY --from=build /build/org.hl7.fhir.publisher.cli/target/org.hl7.fhir.publisher.cli-*-SNAPSHOT.jar /usr/src/app/org.hl7.fhir.publisher.cli.jar
-ENTRYPOINT ["java", "-jar", "/usr/src/app/org.hl7.fhir.publisher.cli.jar"]
+USER $APPLICATION_USER
+COPY --from=build /build/org.hl7.fhir.publisher.cli/target/org.hl7.fhir.publisher.cli-*-SNAPSHOT.jar /app/org.hl7.fhir.publisher.cli.jar
+ENTRYPOINT ["java", "-jar", "/app/org.hl7.fhir.publisher.cli.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM maven:3.6.3-jdk-11 AS build
+WORKDIR /build
+COPY lib ./lib
+COPY pom.xml ./pom.xml
+COPY org.hl7.fhir.publisher.cli/pom.xml ./org.hl7.fhir.publisher.cli/pom.xml
+COPY org.hl7.fhir.publisher.core/pom.xml ./org.hl7.fhir.publisher.core/pom.xml
+RUN mvn dependency:go-offline
+COPY . .
+RUN mvn install -Dmaven.test.skip=true
+
+FROM eclipse-temurin:11
+WORKDIR /usr/src/app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git ruby-full build-essential zlib1g-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    gem install jekyll
+
+COPY --from=build /build/org.hl7.fhir.publisher.cli/target/org.hl7.fhir.publisher.cli-*-SNAPSHOT.jar /usr/src/app/org.hl7.fhir.publisher.cli.jar
+ENTRYPOINT ["java", "-jar", "/usr/src/app/org.hl7.fhir.publisher.cli.jar"]

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ You can find detailed instructions on setting up this project in your IDE [here]
 
 This project uses [Apache Maven][Link-Maven] to build. To build:
 
-```
+```shell
 mvn install
 ```
 
 To skip unit tests:
 
-```
+```shell
 mvn -Dmaven.test.skip install
 ```
 
@@ -60,6 +60,32 @@ In addition, two common publishing tasks that can be accomplished using the fhir
 
 * [Publishing Packages](https://hl7.github.io/docs/ig_publisher/publishing-packages)
 * [Publishing Templates](https://hl7.github.io/docs/ig_publisher/publishing-templates)
+
+## Docker
+
+A Dockerfile exists for packaging the IG Publisher and its pre-requisite software as a Docker image.
+
+To build the Docker image from within the project directory:
+
+```shell
+docker build -t fhir-ig-publisher:test .
+```
+
+You can use `docker run` to run the built docker image. Arguments in the Docker run command will be passed to the 
+IG Publisher CLI. If you include the --rm parameter, the container by the run command generated will be removed after 
+the command has been executed. If you wish to debug the container after a run, exclude this parameter.
+
+```shell
+docker run --rm fhir-ig-publisher:test
+```
+
+*Note: you will have to mount local files and directories in order for them to be accessed by the Docker container.*
+
+```shell
+docker run --mount type=bind,src=/path/to/an/ig-directory,dst=/usr/src/ig --rm fhir-ig-publisher:test -ig /usr/src/ig
+```
+
+
 
 ## Releases
 


### PR DESCRIPTION
This supersedes this PR: https://github.com/HL7/fhir-ig-publisher/pull/97 initially created by @chgl.

After review, the Docker image in that PR refused to build. This PR fixes the issue by updating to a modern Jekyll install, and permits execution of common IG tasks with the build image.

Closes https://github.com/HL7/fhir-ig-publisher/issues/93

> To make this really useful, this repository should be connected to Docker Hub to automatically build and publish the container image.

This will follow; for now, the pipeline builds but does not yet push the image.