### PR TITLE
#1079: Fixed CqlSubsystem referencing included CQL libraries incorrectly

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/CqlSubSystem.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/CqlSubSystem.java
@@ -928,7 +928,10 @@ public class CqlSubSystem {
 
   private CompiledLibrary resolveLibrary(String localLibraryName, CompiledLibrary library, LibraryManager libraryManager) {
     IncludeDef includeDef = library.resolveIncludeRef(localLibraryName);
-    return resolveLibrary(libraryManager, new VersionedIdentifier().withId(includeDef.getPath()).withVersion(includeDef.getVersion()));
+    return resolveLibrary(libraryManager, new VersionedIdentifier()
+            .withId(NamespaceManager.getNamePart(includeDef.getPath()))
+            .withSystem(NamespaceManager.getUriPart(includeDef.getPath()))
+            .withVersion(includeDef.getVersion()));
   }
 
   private CompiledLibrary resolveLibrary(LibraryManager libraryManager, VersionedIdentifier libraryIdentifier) {


### PR DESCRIPTION
Incorrect behavior can be seen on this branch of the Opioid IG: https://github.com/cqframework/opioid-cds-r4/tree/2024-ig-eoy-update