### PR TITLE
Fix jekyll steps in exec tests on Windows

### DIFF
--- a/build-and-exec-jobs-template.yml
+++ b/build-and-exec-jobs-template.yml
@@ -16,9 +16,9 @@ jobs:
         steps:
 
           - task: UseRubyVersion@0
-            condition: ne( variables['Agent.OS'], 'Windows_NT' )
+            # condition: ne( variables['Agent.OS'], 'Windows_NT' )
             inputs:
-              versionSpec: '>= 3.0'
+              versionSpec: '>= 3.3'
 
           - script : |
               ridk enable

--- a/build-and-exec-jobs-template.yml
+++ b/build-and-exec-jobs-template.yml
@@ -22,15 +22,16 @@ jobs:
 
           - script : |
               ridk enable
-              ridk install 3.3
+              ridk install 3
             condition: eq( variables['Agent.OS'], 'Windows_NT' )
             displayName: 'winget for ruby install'
 
           - script: |
-              gem install jekyll bundler
+              gem install bundler
               bundle init
               bundle update --bundler
               bundle install --retry=3 --jobs=4
+              gem install jekyll
             displayName: 'jekyll install'
 
           - script: |

--- a/build-and-exec-jobs-template.yml
+++ b/build-and-exec-jobs-template.yml
@@ -21,7 +21,7 @@ jobs:
               versionSpec: '>= 3.0'
 
           - script : |
-              winget install -e --id RubyInstallerTeam.RubyWithDevKit
+              ridk install 3
             condition: eq( variables['Agent.OS'], 'Windows_NT' )
             displayName: 'winget for ruby install'
 

--- a/build-and-exec-jobs-template.yml
+++ b/build-and-exec-jobs-template.yml
@@ -16,7 +16,6 @@ jobs:
         steps:
 
           - task: UseRubyVersion@0
-            # condition: ne( variables['Agent.OS'], 'Windows_NT' )
             inputs:
               versionSpec: '>= 3.3'
 
@@ -24,7 +23,7 @@ jobs:
               ridk enable
               ridk install 3
             condition: eq( variables['Agent.OS'], 'Windows_NT' )
-            displayName: 'winget for ruby install'
+            displayName: 'ridk to install devkit'
 
           - script: |
               gem install bundler

--- a/build-and-exec-jobs-template.yml
+++ b/build-and-exec-jobs-template.yml
@@ -23,7 +23,7 @@ jobs:
           - script : |
               winget install -e --id RubyInstallerTeam.RubyWithDevKit
             condition: eq( variables['Agent.OS'], 'Windows_NT' )
-            displayName: 'ridk for ruby install'
+            displayName: 'winget for ruby install'
 
           - script: |
               gem install jekyll bundler

--- a/build-and-exec-jobs-template.yml
+++ b/build-and-exec-jobs-template.yml
@@ -22,7 +22,7 @@ jobs:
 
           - script : |
               ridk enable
-              ridk install 3
+              ridk install 3.3
             condition: eq( variables['Agent.OS'], 'Windows_NT' )
             displayName: 'winget for ruby install'
 

--- a/build-and-exec-jobs-template.yml
+++ b/build-and-exec-jobs-template.yml
@@ -21,6 +21,7 @@ jobs:
               versionSpec: '>= 3.0'
 
           - script : |
+              ridk enable
               ridk install 3
             condition: eq( variables['Agent.OS'], 'Windows_NT' )
             displayName: 'winget for ruby install'


### PR DESCRIPTION
Windows runners are failing to correctly install Jekyll, resulting in failed exec tests.