### PR TITLE
Improved output for failed QA Delta runs

### DIFF
--- a/.github/actions/publish-ig-and-cache-qa/action.yml
+++ b/.github/actions/publish-ig-and-cache-qa/action.yml
@@ -93,7 +93,7 @@ runs:
       if: steps.run-publisher.outcome != 'success'
       run: |
         mkdir -p ${{ env.TARGET_DIRECTORY }}/output
-        echo "IG Publish step failed. Check for warnings in https://github.com/HL7/fhir-ig-publisher/actions/runs/${{ github.run_id }} for ${{ inputs.ig }}" > ${{ env.TARGET_DIRECTORY }}/output/qa.compare.txt
+        echo "IG Publish step failed. Check for warnings in https://github.com/HL7/fhir-ig-publisher/actions/runs/${{ github.run_id }} for ${{ inputs.ig }} and IG Publisher ${{ inputs.ref }}" > ${{ env.TARGET_DIRECTORY }}/output/qa.compare.txt
         echo "::warning::IG Publish step failed."
       shell: bash
     - name: Move QA to project root


### PR DESCRIPTION
Output for QA delta will include a link pointing to the failed run with IG and branch information.