### PR TITLE
Allow QA Delta to run with branch of org.hl7.fhir.core

### DIFF
--- a/.github/actions/build-and-cache-ig-publisher/action.yml
+++ b/.github/actions/build-and-cache-ig-publisher/action.yml
@@ -27,7 +27,7 @@ runs:
         path: ${{ github.workspace }}/core-build
     - name: Build Core Project
       if: inputs.core-ref != ''
-      run: mvn clean install -Dmaven.test.skip=true
+      run: mvn clean install -DskipTests
       shell: bash
       working-directory: ${{ github.workspace }}/core-build
     - name: Checkout IG Publisher Project

--- a/.github/actions/build-and-cache-ig-publisher/action.yml
+++ b/.github/actions/build-and-cache-ig-publisher/action.yml
@@ -18,13 +18,25 @@ runs:
       with:
         java-version: 17
         distribution: zulu
-    - name: Checkout project
+    - name: Checkout Core Project
+      if: inputs.core-ref != ''
+      uses: actions/checkout@v4
+      with:
+        repository: hapifhir/org.hl7.fhir.core
+        ref: ${{ inputs.core-ref }}
+        path: ${{ github.workspace }}/core-build
+    - name: Build Core Project
+      if: inputs.core-ref != ''
+      run: mvn clean install -Dmaven.test.skip=true
+      shell: bash
+      working-directory: ${{ github.workspace }}/core-build
+    - name: Checkout IG Publisher Project
       uses: actions/checkout@v4
       with:
         repository: HL7/fhir-ig-publisher
         ref: ${{ inputs.ref }}
         path: ${{ github.workspace }}/ig-publisher-cli-build
-    - name: Build with Maven
+    - name: Build IG Publisher
       run: mvn clean install -Dmaven.test.skip=true
       shell: bash
       working-directory: ${{ github.workspace }}/ig-publisher-cli-build

--- a/.github/actions/build-and-cache-ig-publisher/action.yml
+++ b/.github/actions/build-and-cache-ig-publisher/action.yml
@@ -5,6 +5,9 @@ inputs:
     description: "The GitHub ref to build the IG publisher from"
     required: false
     default: "master"
+  core-ref:
+    description: "An optional ref to build the core library from"
+    required: false
 
 runs:
   using: "composite"

--- a/.github/workflows/delta.yml
+++ b/.github/workflows/delta.yml
@@ -3,9 +3,13 @@ on:
   workflow_dispatch:
     inputs:
       actual-ref:
-        description: 'Commit SHA'
+        description: 'IG Publisher Commit SHA'
         required: false
         default: 'master'
+        type: string
+      core-ref:
+        description: 'org.hly.fhir.core Commit SHA'
+        required: false
         type: string
 
 permissions:  # added using https://github.com/step-security/secure-repo
@@ -75,10 +79,18 @@ jobs:
         with:
           sparse-checkout: |
             .github
-      - name: Build and Cache IG Publisher
+      - name: Build and Cache IG Publisher (ref)
         uses: ./.github/actions/build-and-cache-ig-publisher
+        if: matrix.ref == inputs.actual-ref
         with:
           ref: ${{ matrix.ref }}
+          core-ref: ${{ inputs.core-ref }}
+      - name: Build and Cache IG Publisher (latest release)
+        uses: ./.github/actions/build-and-cache-ig-publisher
+        if: matrix.ref != inputs.actual-ref
+        with:
+          ref: ${{ matrix.ref }}
+
 
   generate-and-cache-qa:
     name: Generate and cache QA


### PR DESCRIPTION
When running the QA Delta action, you can now include a branch of core to be used on building the IG Publisher. 

In the screencap below, the **IG Publisher Commit SHA** and **org.hl7.fhir.core Commit SHA** are both able to be set to branch names or commit hashes.

If **org.hl7.fhir.core Commit SHA** is left blank, org.hl7.fhir.core builds will be pulled from whatever is available on public maven repositories.

If **org.hl7.fhir.core Commit SHA** is a valid branch or commit, org.hl7.fhir.core will be built in the workflow and IG Publisher will use that version instead of attempting to download it.

<img width="1046" height="476" alt="Screenshot 2025-10-02 at 1 33 13 PM" src="https://github.com/user-attachments/assets/f61f36ee-fbec-464b-bf64-d3cc0b5e2143" />
