### PR TITLE
Bump upstream dependencies to bring angus-mail to 2.0.5

### DIFF
--- a/org.hl7.fhir.publisher.core/pom.xml
+++ b/org.hl7.fhir.publisher.core/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.moxy</artifactId>
-            <version>4.0.7</version>
+            <version>4.0.8</version>
         </dependency>
         <!-- Jackson FasterXML -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>4.0.5</version>
+                <version>4.0.6</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
org.eclipse.persistence.moxy -> 4.0.8
jaxb-runtime -> 4.0.6