### PR TITLE
Use ManagedWebAccess for `-no-network` param

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -1460,7 +1460,7 @@ public class Publisher extends PublisherBase implements IReferenceResolver, IVal
         parseAndAddNoValidateParam(self, param);
       }
       if (CliParams.hasNamedParam(args, "-no-network")) {
-        FhirSettings.setProhibitNetworkAccess(true);
+        ManagedWebAccess.setAccessPolicy(ManagedWebAccess.WebAccessPolicy.PROHIBITED);
       }
       if (CliParams.hasNamedParam(args, "-trackFragments")) {
         self.settings.setTrackFragments(true);


### PR DESCRIPTION
FhirSettings.setProhibitNetworkAccess is deprecated, and we should replace its usage.