### PR TITLE
Fix support for SSH-style Git URLs (fixes #1204)

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/GitUtilities.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/GitUtilities.java
@@ -69,12 +69,20 @@ public class GitUtilities {
 	 * <p/>
 	 * This will also send log info to console that reports user information removal, as well as a malformed URL
 	 * resulting in a null return.
+	 * <p/>
+	 * SSH-style Git URLs (e.g., git@github.com:org/repo.git) are supported and returned as-is since they
+	 * don't contain embedded credentials.
 	 *
 	 * @param url The URL
 	 * @param urlSource A string representing the source of the URL to be output (CLI param, git remote, etc.)
 	 * @return A valid URL that does not contain user information or null if the url param was malformed.
 	 */
 	protected static String getURLWithNoUserInfo(final String url, final String urlSource) {
+		// Handle SSH-style Git URLs (e.g., git@github.com:org/repo.git)
+		// These don't contain embedded passwords (they use SSH keys) so are safe to return as-is
+		if (url != null && url.matches("^[a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+:.*$")) {
+			return url;
+		}
 		try {
 			URL newUrl = new URL(url);
             if (newUrl.getUserInfo() != null) {

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/GitUtilitiesTests.java
@@ -25,6 +25,7 @@ public class GitUtilitiesTests {
 
 	public static final String VALID_URL = "https://github.com/FHIR/fhir-core-examples.git";
 	public static final String USERNAME_AND_TOKEN_URL = "https://username:token@github.com/FHIR/fhir-core-examples.git";
+	public static final String SSH_URL = "git@github.com:FHIR/fhir-core-examples.git";
 	public static final String NORMAL_BRANCH = "normal-branch";
 	public static final String WORKTREE_BRANCH = "branch-a";
 
@@ -98,7 +99,8 @@ public class GitUtilitiesTests {
 	@CsvSource(value= {
 			VALID_URL+","+VALID_URL,
 			"whwehwhasdlksdjsdf,''",
-			USERNAME_AND_TOKEN_URL+","+ VALID_URL})
+			USERNAME_AND_TOKEN_URL+","+ VALID_URL,
+			SSH_URL+","+SSH_URL})
 	void testGetGitSource(String url, String expected) throws IOException, InterruptedException {
 		File gitRoot = initiateGitDirectory();
 		createOriginURL(gitRoot, url);
@@ -110,7 +112,9 @@ public class GitUtilitiesTests {
 	@CsvSource(value= {
 			VALID_URL+","+VALID_URL,
 			"whwehwhasdlksdjsdf,NULL",
-			USERNAME_AND_TOKEN_URL+","+VALID_URL}, nullValues={"NULL"})
+			USERNAME_AND_TOKEN_URL+","+VALID_URL,
+			SSH_URL+","+SSH_URL,
+			"deploy@gitlab.example.com:org/repo.git,deploy@gitlab.example.com:org/repo.git"}, nullValues={"NULL"})
 	public void testGetURLWithNoUserInfo(String url, String expected) {
 		String result = GitUtilities.getURLWithNoUserInfo(url, "test");
 		assertThat(result).isEqualTo(expected);


### PR DESCRIPTION
Add handling for SSH-style Git URLs like git@github.com:org/repo.git in getURLWithNoUserInfo(). These URLs are not valid according to java.net.URL parsing, but are safe to return as-is since they don't contain embedded credentials (they use SSH keys).

The fix adds a regex check to detect SSH URL format before attempting standard URL parsing.