### PR TITLE
Br updates 2025 12

### DIFF
--- a/org.hl7.fhir.publisher.core/pom.xml
+++ b/org.hl7.fhir.publisher.core/pom.xml
@@ -48,6 +48,11 @@
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
+            <artifactId>elm-fhir</artifactId>
+            <version>${info_cqframework_version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cqframework</groupId>
             <artifactId>elm-jaxb</artifactId>
             <version>${info_cqframework_version}</version>
         </dependency>

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/loaders/AdjunctFileLoader.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/loaders/AdjunctFileLoader.java
@@ -91,12 +91,12 @@ public class AdjunctFileLoader {
           att.getAttachment().setData(a.getData());
           att.getAttachment().setContentType(a.getContentType());
           // Library - post processing needed
-          if (r.getResource() instanceof Library && "text/cql".equals(a.getContentType())) {
-            // we just injected CQL into a library 
+          if (r.getResource() instanceof Library && ("text/cql".equals(a.getContentType()) || "application/xml".equals(a.getContentType()))) {
+            // we just injected CQL or a CQL ModelInfo into a library
             try {
               performLibraryCQLProcessing(f, (Library) r.getResource(), a);
             } catch (Exception ex) {
-              f.getErrors().add(new ValidationMessage(Source.InstanceValidator, IssueType.EXCEPTION, att.getPath(), "Error processing CQL: " +ex.getMessage(), IssueSeverity.ERROR));              
+              f.getErrors().add(new ValidationMessage(Source.InstanceValidator, IssueType.EXCEPTION, att.getPath(), "Error processing CQL or CQL Model Info: " +ex.getMessage(), IssueSeverity.ERROR));
             }
           }
         } catch (Exception ex) {
@@ -314,7 +314,9 @@ public class AdjunctFileLoader {
     CqlSourceFileInformation info = cql.getFileInformation(attachment.getUrl());
     if (info != null) {
       f.getErrors().addAll(info.getErrors());
-      lib.addContent().setContentType("application/elm+xml").setData(info.getElm());
+      if (info.getElm() != null) {
+        lib.addContent().setContentType("application/elm+xml").setData(info.getElm());
+      }
       if (info.getJsonElm() != null) {
         lib.addContent().setContentType("application/elm+json").setData(info.getJsonElm());
       }


### PR DESCRIPTION
* Fixed npm model info loader not using the model info reader factory
* AdjunctFileLoader now supports CQL modelinfo files
* Corrected AdjunctFileLoader support XML format output setting in cql-options
* Fixed ELM data requirements incorrectly resolving code system references in value set, code, and concept declarations
* Added support for setting whether or not to correct model URLs
* Added logic to fixup references to implicitly loaded ModelInfo so the correct dependencies are reported
* Added effective data requirements processing for Measure, ActivityDefinition, PlanDefinition, and Questionnaire resources