### PR TITLE
Skip dependency resources in output generation, fixes QA errors in dependent IGs with translations

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java
@@ -613,6 +613,9 @@ public class PublisherGenerator extends PublisherBase {
 
   private void generateNativeOutputs(FetchedFile f, boolean regen, DBBuilder db) throws IOException, FHIRException, SQLException {
     for (FetchedResource r : f.getResources()) {
+      if (isFromDependency(r)) {
+        continue;
+      }
       logDebugMessage(LogCategory.PROGRESS, "Produce resources for "+r.fhirType()+"/"+r.getId());
       var json = saveNativeResourceOutputs(f, r);
       if (db != null) {
@@ -705,7 +708,9 @@ public class PublisherGenerator extends PublisherBase {
     lrc = lrc.copy(true); // whatever happens in here shouldn't alter the settings on the base RenderingContext
     saveFileOutputs(f, lang);
     for (FetchedResource r : f.getResources()) {
-
+      if (isFromDependency(r)) {
+        continue;
+      }
       logDebugMessage(LogCategory.PROGRESS, "Produce outputs for "+r.fhirType()+"/"+r.getId());
       Map<String, String> vars = makeVars(r);
       makeTemplates(f, r, vars, lang, lrc);
@@ -827,6 +832,9 @@ public class PublisherGenerator extends PublisherBase {
       // nothing
     } else {
       for (FetchedResource r : f.getResources()) {
+        if (isFromDependency(r)) {
+          continue;
+        }
         Map<String, String> vars = makeVars(r);
         if (r.getResource() != null) {
           generateResourceSpreadsheets(f, regen, r, r.getResource(), vars, "", db);
@@ -889,6 +897,14 @@ public class PublisherGenerator extends PublisherBase {
       return false;
     else
       return igr.getIsExample();
+  }
+
+  private boolean isFromDependency(FetchedResource r) {
+    String url = r.getElement().getChildValue("url");
+    if (url == null) {
+      return false;
+    }
+    return !url.startsWith(pf.igpkp.getCanonical());
   }
 
 

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherProcessor.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherProcessor.java
@@ -1938,13 +1938,23 @@ public class PublisherProcessor extends PublisherBase  {
       f.start("translate");
       try {
         for (FetchedResource r : f.getResources()) {
-          pt.translate(f, r);
+          if (!isFromDependency(r)) {
+            pt.translate(f, r);
+          }
         }
       } finally {
         f.finish("translate");
       }
     }
     pt.finish();
+  }
+
+  private boolean isFromDependency(FetchedResource r) {
+    String url = r.getElement().getChildValue("url");
+    if (url == null) {
+      return false;
+    }
+    return !url.startsWith(pf.igpkp.getCanonical());
   }
 
 


### PR DESCRIPTION
When an IG depends on another IG with multi-language mode enabled, dependency resources are incorrectly rendered in the output, causing QA errors for missing CSV/XLSX/SCH files.

This PR skips resources whose canonical URL doesn't match the current IG's canonical during output generation.

Test plan -

- Build an IG that depends on another IG with multi-language mode enabled
- Verify dependency resources no longer appear in the output
- Verify QA errors for missing CSV/XLSX/SCH files are eliminated