### PR TITLE
Use specialised renderers for logical model instances

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java
@@ -1118,7 +1118,7 @@ public class PublisherGenerator extends PublisherBase {
         String html = null;
         if (rX.getLogicalElement() != null) {
           // Try to use a specialised renderer for this logical model.
-          String logicalType = fhirTypeRoot(rX.getLogicalElement().fhirType());
+          String logicalType = rX.getLogicalElement().fhirTypeRoot();
           RenderingContext xlrc = lrc.copy(false);
           xlrc.setRules(RenderingContext.GenerationRules.IG_PUBLISHER);
           ResourceRenderer rr = RendererFactory.factory(logicalType, xlrc);
@@ -6994,21 +6994,5 @@ public class PublisherGenerator extends PublisherBase {
       ExtensionUtilities.removeExtension(r, ExtensionDefinitions.EXT_IGP_RESOURCE_INFO);
   }
 
-  /**
-   * Extracts the type name from a FHIR type that may be a URL.
-   *
-   * <p>For logical models, the fhirType is a URL like
-   * "https://sql-on-fhir.org/ig/StructureDefinition/ViewDefinition". This method extracts just
-   * the final segment ("ViewDefinition") for use with RendererFactory.
-   *
-   * @param fhirType The FHIR type, which may be a simple name or a URL.
-   * @return The type name (final path segment if a URL, otherwise the input unchanged).
-   */
-  private static String fhirTypeRoot(String fhirType) {
-    if (fhirType != null && fhirType.contains("/")) {
-      return fhirType.substring(fhirType.lastIndexOf("/") + 1);
-    }
-    return fhirType;
-  }
 
 }


### PR DESCRIPTION
When rendering logical model instances (Binary resources containing logical model data), the publisher now attempts to use specialised renderers from `RendererFactory` instead of always displaying raw JSON/XML.

For example, a `ViewDefinition` instance will now render using `ViewDefinitionRenderer` if available, producing a more readable narrative than syntax-highlighted JSON.

This restores functionality previously worked, but a regression broke it at some point.

**Changes:**
- Query `RendererFactory` for a specialised renderer matching the logical model type
- If one exists (i.e., not the generic `ProfileDrivenRenderer`), use it to build the narrative
- Fall back to JSON/XML rendering if no specialised renderer exists or if rendering fails
- Add null safety checks for `contentType` to prevent NPEs

**Fallback behaviour:** If the specialised renderer throws an exception or returns null, the code gracefully falls back to the existing JSON/XML rendering, ensuring no regression for edge cases.