### PR TITLE
perf: cache NamingSystem URLs and send usage stats asynchronously

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/ValidationServices.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/ValidationServices.java
@@ -98,6 +98,7 @@ public class ValidationServices implements IValidatorResourceFetcher, IValidatio
   private List<PublisherUtils.LinkedSpecification> linkSpecMaps;
   private IPublisherModule module;
   private static boolean nsFailHasFailed = false; // work around for an THO 6.0.0 problem
+  private Set<String> namingSystemUrls; // cached URL set for resolveURL lookups
   
   
   public ValidationServices(IWorkerContext context, IGKnowledgeProvider ipg, ImplementationGuide ig, List<FetchedFile> files, List<NpmPackage> packages,
@@ -384,11 +385,22 @@ public class ValidationServices implements IValidatorResourceFetcher, IValidatio
       }
     }
     try {
-      for (NamingSystem ns : context.fetchResourcesByType(NamingSystem.class)) {
-        if (hasURL(ns, u)) {
-          // ignore the version?
-          return true;
+      if (namingSystemUrls == null) {
+        namingSystemUrls = new HashSet<>();
+        for (NamingSystem ns : context.fetchResourcesByType(NamingSystem.class)) {
+          for (NamingSystemUniqueIdComponent uid : ns.getUniqueId()) {
+            if (uid.hasValue()) {
+              if (uid.getType() == NamingSystemIdentifierType.URI) {
+                namingSystemUrls.add(uid.getValue());
+              } else if (uid.getType() == NamingSystemIdentifierType.OID) {
+                namingSystemUrls.add("urn:oid:" + uid.getValue());
+              }
+            }
+          }
         }
+      }
+      if (namingSystemUrls.contains(u)) {
+        return true;
       }
     } catch (Exception e) {
       if (!nsFailHasFailed) {


### PR DESCRIPTION
## Summary

Two changes:

1. **`ValidationServices.resolveURL()`**: Cache NamingSystem URLs in a `HashSet` on first use, then do O(1) lookups instead of iterating all NamingSystems on every call. This method is called for every URL resolved during validation. (168 CPU samples in JFR profiling against US Core 9.0.0)

2. **`PublisherGenerator`**: Send usage statistics via a daemon thread instead of blocking the main thread with an HTTP call.

## A/B Benchmark

Part of a set of independent changes across Core and Publisher producing 31% overall speedup on US Core 9.0.0. Full details: https://github.com/jmandel/igpublisher-perf