### PR TITLE
fix: prioritize special package handlers over meta.source fallback in getPath()

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/SpecMapManager.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/SpecMapManager.java
@@ -205,9 +205,6 @@ public class SpecMapManager {
     if (path != null) {
       return path;
     }
-    if (def != null) {
-      return def;
-    }
     if (special != null) {
       switch (special) {
       case FACADE:
@@ -271,6 +268,9 @@ public class SpecMapManager {
           return null;
         }
       }
+    }
+    if (def != null) {
+      return def;
     }
     if (url.matches(Constants.URI_REGEX)) {
       int cc = 0;


### PR DESCRIPTION
## Bug

`SpecMapManager.getPath()` uses `meta.source` (passed as the `def` parameter) as a web hyperlink for resources from dependency packages **before** the special package type handlers (Simplifier, VSAC, DICOM, etc.) are reached.

`meta.source` is a provenance URI per the FHIR spec — not a navigable web URL. The special package handlers exist specifically to generate correct links for their respective package types, but are never invoked when `meta.source` is non-null.

### Call sites passing `meta.source` as `def`

| Call site | File | Line |
|-----------|------|------|
| `getResourcePath()` | `PublisherLoader.java` | 77 |
| `getIgPath()` | `PublisherLoader.java` | 97 |
| `getCorePath()` | `LoaderUtils.java` | 30, 34 |

All pass `resource.getMeta().getSource()` as the `def` parameter.

### Fallback order before this fix

```
1. paths map (spec.internals)  → return if found
2. getSpecialPath()            → return if match
3. def (meta.source) != null   → return def          ← SHORT-CIRCUITS EVERYTHING BELOW
4. special package handlers    → Simplifier/VSAC/DICOM/PhinVads (never reached)
5. URI regex fallback
6. return null
```

### Fallback order after this fix

```
1. paths map (spec.internals)  → return if found
2. getSpecialPath()            → return if match
3. special package handlers    → Simplifier/VSAC/DICOM/PhinVads (now reached)
4. def (meta.source) != null   → last-resort fallback
5. URI regex fallback
6. return null
```

### Impact

For Simplifier-published packages (e.g. `nictiz.fhir.nl.r4.zib2020`) that lack `spec.internals` and have `meta.source` set, this produces broken hyperlinks in the generated IG HTML.

**Before:** Link points to `http://decor.nictiz.nl/fhir/4.0/zib2020bbr-` (truncated `meta.source` provenance URI)

**After:** Link points to `https://simplifier.net/resolve?scope=nictiz.fhir.nl.r4.zib2020@0.12.0-beta.4&canonical=...` (correct Simplifier redirect)

A reproduction project is attached to #1275.

Fixes #1275