### PR TITLE
Fix NPE in PublicationChecker when publication-request.json is absent

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/PublicationChecker.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/PublicationChecker.java
@@ -222,7 +222,7 @@ public class PublicationChecker {
 
   private void checkExistingPublication(List<String> messages, NpmPackage npm, PackageList pl, JsonObject pr) {
     if (pl != null) {
-      if (pr.has("movedFrom")) {
+      if (pr != null && pr.has("movedFrom")) {
         check(messages, !npm.name().equals(pl.pid()), "Package ID matches, which is wrong. This package is " + npm.name() + " and the website is also " + pl.pid()+", but it must change" + mkError());
         check(messages, !npm.canonical().equals(pl.canonical()), "Package canonical matches, which is wrong. This package canonical is " + npm.canonical() + " and the website has " + pl.canonical()+", but it must change" + mkError());
         check(messages, !hasVersion(pl, npm.version()), "Version " + npm.version() + " has already been published" + mkWarning());


### PR DESCRIPTION
When an IG has been previously published (canonical serves a valid package-list.json) but the local repo has no publication-request.json, checkExistingPublication NPE'd on pr.has("movedFrom"). 

This treats pr == null as "no movedFrom declared" and fall through to the normal publication-comparison branch.