### PR TITLE
Dependency upgrades

### DIFF
--- a/org.hl7.fhir.publisher.core/pom.xml
+++ b/org.hl7.fhir.publisher.core/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <!-- GraalVM uses the JDK numbering scheme. These should always be LTS versions (17, 21, etc). -->
-        <graalvm.version>25.0.3</graalvm.version>
+        <graalvm.version>21.3.18</graalvm.version>
         <info_cqframework_version>3.29.0</info_cqframework_version>
     </properties>
 

--- a/org.hl7.fhir.publisher.core/pom.xml
+++ b/org.hl7.fhir.publisher.core/pom.xml
@@ -15,8 +15,8 @@
 
     <properties>
         <!-- GraalVM uses the JDK numbering scheme. These should always be LTS versions (17, 21, etc). -->
-        <graalvm.version>21.3.16</graalvm.version>
-        <info_cqframework_version>3.27.0</info_cqframework_version>
+        <graalvm.version>25.0.3</graalvm.version>
+        <info_cqframework_version>3.29.0</info_cqframework_version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.testTarget>17</maven.compiler.testTarget>
         <logback.version>1.5.25</logback.version>
         <log4jVersion>2.25.4</log4jVersion>
-        <jackson_version>2.21</jackson_version>
+        <jackson_version>2.21.3</jackson_version>
         <jackson_annotations_version>2.21</jackson_annotations_version>
         <nedap-healthcare-archie.version>3.16.0</nedap-healthcare-archie.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.testSource>17</maven.compiler.testSource>
         <maven.compiler.testTarget>17</maven.compiler.testTarget>
         <logback.version>1.5.25</logback.version>
-        <log4jVersion>2.25.4</log4jVersion>
+        <log4jVersion>2.26.0</log4jVersion>
         <jackson_version>2.21.3</jackson_version>
         <jackson_annotations_version>2.21</jackson_annotations_version>
         <nedap-healthcare-archie.version>3.16.0</nedap-healthcare-archie.version>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libthrift</artifactId>
+                <version>0.23.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <maven.compiler.testTarget>17</maven.compiler.testTarget>
         <logback.version>1.5.25</logback.version>
         <log4jVersion>2.25.4</log4jVersion>
-        <jackson_version>2.21.1</jackson_version>
+        <jackson_version>2.21</jackson_version>
         <jackson_annotations_version>2.21</jackson_annotations_version>
         <nedap-healthcare-archie.version>3.16.0</nedap-healthcare-archie.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <maven.compiler.testSource>17</maven.compiler.testSource>
         <maven.compiler.testTarget>17</maven.compiler.testTarget>
         <logback.version>1.5.25</logback.version>
-        <log4jVersion>2.25.3</log4jVersion>
+        <log4jVersion>2.25.4</log4jVersion>
         <jackson_version>2.21.1</jackson_version>
         <jackson_annotations_version>2.21</jackson_annotations_version>
         <nedap-healthcare-archie.version>3.16.0</nedap-healthcare-archie.version>


### PR DESCRIPTION
Update:

- graalvm to 21.3.18
- cqframework to 3.29.0
- log4j to 2.25.4
- jackson to 2.21.3
- libthrift to 0.23.0