### PR TITLE
Added support for ImplementationGuide:base, to allow differentiation …

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/IGKnowledgeProvider.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/IGKnowledgeProvider.java
@@ -419,9 +419,12 @@ public class IGKnowledgeProvider implements ProfileKnowledgeProvider, ParserBase
       JsonObject cfg = null;
       if (cfg == null && r.fhirType().equals("StructureDefinition")) {
         cfg = defaultConfig.getJsonObject(r.fhirType()+":"+getSDType(r));
+      } else if (cfg == null && r.fhirType().equals("ImplementationGuide")) {
+        if (!r.getElement().hasChild("experimental") || !r.getElement().getChildValue("experimental").equals("true"))
+          cfg = defaultConfig.getJsonObject(r.fhirType()+":base");
       }
       if (cfg == null)
-        cfg = template.getConfig(r.fhirType(), r.getId());        
+        cfg = template.getConfig(r.fhirType(), r.getId(), false);        
       if (cfg == null && r.isExample()) {
         if (r.isCanonical(context))
           cfg = defaultConfig.getJsonObject("example:canonical");
@@ -436,6 +439,8 @@ public class IGKnowledgeProvider implements ProfileKnowledgeProvider, ParserBase
           cfg = defaultConfig.getJsonObject("Any:canonical");
         }
       }
+      if (cfg == null)
+        cfg = template.getConfig(r.fhirType(), r.getId(), true);        
       r.setConfig(cfg);
     }
     if (r.getConfig() == null && resourceConfig != null) {

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherIGLoader.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherIGLoader.java
@@ -3747,7 +3747,6 @@ public class PublisherIGLoader extends PublisherBase {
             }
             checkResourceUnique(type+"/"+id, file.getPath(), cause);
             r.setElement(e).setId(id).setType(type);
-            pf.igpkp.findConfiguration(file, r);
             binary = false;
           } else {
             id = new File(file.getPath()).getName();
@@ -3755,7 +3754,6 @@ public class PublisherIGLoader extends PublisherBase {
             // are we going to treat it as binary, or something else?
             checkResourceUnique("Binary/"+id, file.getPath(), cause);
             r.setElement(e).setId(id).setType("Binary");
-            pf.igpkp.findConfiguration(file, r);
             binary = true;
           }
         } else {
@@ -3795,7 +3793,6 @@ public class PublisherIGLoader extends PublisherBase {
           }
           r.setId(id);
           r.setElement(e);
-          pf.igpkp.findConfiguration(file, r);
         }
         if (!suppressLoading) {
           if (srcForLoad == null)
@@ -3838,6 +3835,7 @@ public class PublisherIGLoader extends PublisherBase {
             }
           }
         }
+        pf.igpkp.findConfiguration(file, r);
 
         r.setTitle(e.getChildValue("name"));
         Element m = e.getNamedChild("meta");

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/templates/Template.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/templates/Template.java
@@ -536,11 +536,11 @@ public class Template {
     }
   }
 
-  public JsonObject getConfig(String type, String id) {
+  public JsonObject getConfig(String type, String id, boolean allowAny) {
     if (defaults!=null) {
       if (defaults.has(type))
         return (JsonObject)defaults.get(type);
-      else if (defaults.has("Any"))
+      else if (allowAny && defaults.has("Any"))
         return (JsonObject)defaults.get("Any");
     }
     return null;

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <core_version>6.9.8</core_version>
+        <core_version>6.9.9-SNAPSHOT</core_version>
         <maven_surefire_version>3.0.0-M5</maven_surefire_version>
         <apache_poi_version>5.4.1</apache_poi_version>
         <commons_io_version>2.17.0</commons_io_version>


### PR DESCRIPTION
…of the 'primary' ImplementationGuide from any example IGs.  Also fixed the logic so that example templates actually function rather than auto-defaulting to 'ANY' if there isn't a specific resource template.