### PR TITLE
Defer context.unload() until after QA (keep the terminology cache from being overwritten mid-build)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,1 @@
+* Defer `context.unload()` until after QA so the terminology (tx) cache isn't cleared and then partially overwritten mid-build — warm/subsequent builds were re-querying the tx server for results already computed

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -455,6 +455,11 @@ public class Publisher extends PublisherBase implements IReferenceResolver, IVal
         log("Generating QA");
         log("Validation output in "+val.generate(pf.sourceIg.getName(), pf.errors, pf.fileList, Utilities.path(settings.getDestDir() != null ? settings.getDestDir() : pf.outputDir, "qa.html"), pf.suppressedMessages, pinSummary()));
       }
+      // All terminology consumers are done by here: genCombinedPackage() (value-set expansion, in
+      // generator.generate() above) and QA. Unload now -- this performs the final flush of the tx
+      // cache, so the complete cache is persisted to disk. Nothing may use the terminology context
+      // after this point (hapifhir/org.hl7.fhir.core#2473 makes post-unload tx-cache use a hard error).
+      pf.context.unload();
       recordOutcome(null, val);
       buildTracker.setBooleanProperty("status", "complete", true, null);
       buildTracker.save();

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java
@@ -376,7 +376,11 @@ public class PublisherGenerator extends PublisherBase implements BaseRenderer.Re
     for (FetchedFile f : pf.fileList) {
       f.trim();
     }
-    pf.context.unload();
+    // NB: pf.context.unload() intentionally moved to the end of createIg(). genCombinedPackage()
+    // (below, same method) and other later work still use the terminology context; unloading here
+    // flushes+clears the tx cache mid-build, after which those value-set expansions overwrite the
+    // persisted cache with partial data. (As of hapifhir/org.hl7.fhir.core#2473, using the tx cache
+    // after unload() is a hard error.)
     for (RelatedIG ig : pf.relatedIGs) {
       ig.dump();
     }


### PR DESCRIPTION
## Problem

`context.unload()` is called in the generate phase's "Reclaiming memory…" block (`PublisherGenerator`), but QA (`ValidationPresenter`) runs afterwards in `Publisher.createIg()` and still uses the terminology context. `unload()` flushes the tx cache to disk and then **clears** the in-memory caches; QA then repopulates fresh, *partial* caches, and `TerminologyCache`'s write-coalescing `save()` writes those back — **overwriting the complete cache files `unload()` had just written.**

Net effect: most persisted terminology results are discarded at the end of every build, so warm/subsequent builds re-query the tx server for answers the previous build already computed. Measured on US mCODE: a cold build performs ~2,600 persistent stores but only ~230 survive on disk; the SNOMED bucket grows to ~1,029 entries, is flushed in full, then overwritten down to ~86.

## Fix

Move `pf.context.unload()` from the generate-phase reclaim block to the end of `createIg()` (after QA — the last terminology consumer). The final flush then captures everything and the persisted cache stays complete. The only cost is holding the terminology context through QA, which QA needs anyway.

## Impact (measured)

We profiled cold-vs-warm terminology traffic across a random sample of published HL7 IGs. Warm-cache effectiveness (the fraction of cold tx round-trips a warm build avoids) was poor precisely for terminology-heavy clinical IGs:

- light terminology: registry-protocols 100%, smart-scheduling-links 97%, smart-app-launch 89%
- heavy terminology: US-Core 50%, physical-activity 44%, CARIN-BB 36%, IPS 30%, PQ-CMC-FDA 28%, mCODE 21%, ICHOM-breast-cancer 18%

The low numbers are explained by this bug. Demonstration on mCODE (baseline vs this fix, cold then warm, identical inputs, requests captured via a logging proxy):

| | warm tx calls | on-disk cache entries (after cold) | QA result |
|---|--:|--:|---|
| baseline | 2,169 | 234 | 8 errors / 117 warnings |
| **with this fix** | **69** | **2,532** | 8 errors / 117 warnings |

Warm terminology-server calls drop ~97%, the complete cache persists (~10× more entries on disk), and validation output is unchanged.

## Notes

- Minimal change — moves one line (plus a comment and a release note).
- The underlying `TerminologyCache.save()` full-file overwrite is also a latent fragility (a partial re-save after `unload()` clobbers the complete file); that could be separately hardened in `org.hl7.fhir.core`, but this publisher change fixes the root cause.
- Marked **draft** pending review and a regression test.
