### PR TITLE
Fix cloud/static-hosting redirects: emit real HTML and wire CLOUD into go-publish

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/IGReleaseRedirectionBuilder.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/IGReleaseRedirectionBuilder.java
@@ -91,31 +91,24 @@ public class IGReleaseRedirectionBuilder {
       "    \r\n"+
       "You should not be seeing this page. If you do, PHP has failed badly.\r\n";
 
-  private static final String HTML_TEMPLATE = "<?php\r\n"+
-      "function Redirect($url)\r\n"+
-      "{\r\n"+
-      "  header('Location: ' . $url, true, 302);\r\n"+
-      "  exit();\r\n"+
-      "}\r\n"+
-      "\r\n"+
-      "$accept = $_SERVER['HTTP_ACCEPT'];\r\n"+
-      "if (strpos($accept, 'application/json+fhir') !== false)\r\n"+
-      "  Redirect('{{literal}}.json2');\r\n"+
-      "elseif (strpos($accept, 'application/fhir+json') !== false)\r\n"+
-      "  Redirect('{{literal}}.json1');\r\n"+
-      "elseif (strpos($accept, 'json') !== false)\r\n"+
-      "  Redirect('{{literal}}.json');\r\n"+
-      "elseif (strpos($accept, 'application/xml+fhir') !== false)\r\n"+
-      "  Redirect('{{literal}}.xml2');\r\n"+
-      "elseif (strpos($accept, 'application/fhir+xml') !== false)\r\n"+
-      "  Redirect('{{literal}}.xml1');\r\n"+
-      "elseif (strpos($accept, 'html') !== false)\r\n"+
-      "  Redirect('{{html}}');\r\n"+
-      "else \r\n"+
-      "  Redirect('{{literal}}.xml');\r\n"+
-      "?>\r\n"+
-      "    \r\n"+
-      "You should not be seeing this page. If you do, PHP has failed badly.\r\n";
+  // Static HTML redirect for cloud / static hosting (e.g. S3, GitHub Pages, Netlify)
+  // that cannot execute server-side scripts. Content negotiation on the Accept header
+  // is not possible without a server runtime, so this redirects browsers to the human
+  // readable page and links the JSON/XML representations for machine clients.
+  private static final String HTML_TEMPLATE = "<!DOCTYPE html>\r\n"+
+      "<html lang=\"en\">\r\n"+
+      "<head>\r\n"+
+      "  <meta charset=\"utf-8\"/>\r\n"+
+      "  <meta http-equiv=\"refresh\" content=\"0; url={{html}}\"/>\r\n"+
+      "  <link rel=\"canonical\" href=\"{{html}}\"/>\r\n"+
+      "  <title>Redirecting&hellip;</title>\r\n"+
+      "  <script type=\"text/javascript\">window.location.replace(\"{{html}}\");</script>\r\n"+
+      "</head>\r\n"+
+      "<body>\r\n"+
+      "  <p>This FHIR resource is published at <a href=\"{{html}}\">{{html}}</a>. Redirecting now&hellip;</p>\r\n"+
+      "  <p>Machine-readable formats: <a href=\"{{literal}}.json\">JSON</a> &middot; <a href=\"{{literal}}.xml\">XML</a></p>\r\n"+
+      "</body>\r\n"+
+      "</html>\r\n";
   
   private static final String WC_START_ROOT = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + 
       "<configuration>\n" + 

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/PublicationProcess.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/PublicationProcess.java
@@ -1059,6 +1059,8 @@ public class PublicationProcess {
       IGReleaseRedirectionBuilder rb = new IGReleaseRedirectionBuilder(destVer, pl.canonical(), plVer.path(), rootFolder);
       if (serverType == ServerType.APACHE) {
         rb.buildApacheRedirections();
+      } else if (serverType == ServerType.CLOUD) {
+        rb.buildCloudRedirections();
       } else if (serverType == ServerType.ASP2) {
         rb.buildNewAspRedirections(false, false);
       } else if (serverType == ServerType.ASP1) {


### PR DESCRIPTION
## Problem

`ServerType.CLOUD` (`"server": "cloud"` in `publish-setup.json`) is intended for static
hosts — S3, GitHub Pages, Netlify, etc. that cannot execute server-side redirect
scripts. Two defects make the CLOUD path non-functional, so a cloud-hosted IG cannot get
working canonical-URL redirects.

### Bug 1: `HTML_TEMPLATE` is a copy of `PHP_TEMPLATE`
`IGReleaseRedirectionBuilder.HTML_TEMPLATE` is a verbatim duplicate of `PHP_TEMPLATE`,
so `createHtmlRedirect()` writes PHP source into `index.html`. A static host serves that
as `text/html`, so the browser renders the raw PHP (including the trailing
"…PHP has failed badly" text) and never redirects.

### Bug 2: `-go-publish` never selects the CLOUD path
`PublicationProcess.updatePublishBox` (the `-go-publish` path) has no `CLOUD` branch, so
cloud sites fall through to `else if (!canonical.contains("hl7.org/fhir"))` →
`buildApacheRedirections()` and get PHP regardless of the configured server type.
(`IGReleaseUpdater` already handles `CLOUD`; this brings the go-publish path into line.)

## Fix

1. Replace `HTML_TEMPLATE` with a real static HTML redirect: `<meta http-equiv="refresh">`
   + `window.location.replace(...)` + `<link rel="canonical">`, plus JSON/XML links for
   machine clients. Content negotiation on `Accept` is not possible without a server
   runtime, so browsers are sent to the human-readable page.
2. Add the missing `else if (serverType == ServerType.CLOUD) rb.buildCloudRedirections();`
   case to `PublicationProcess.updatePublishBox`, matching `IGReleaseUpdater`.

## Testing

`mvn -pl org.hl7.fhir.publisher.core compile` passes. Generated `index.html` verified to
redirect correctly for ImplementationGuide / StructureDefinition / CodeSystem / ValueSet
canonical paths.
