### PR TITLE
Add opt-in -reuse-build to go-publish: skip the redundant -publish re-render

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/Publisher.java
@@ -683,6 +683,11 @@ public class Publisher extends PublisherBase implements IReferenceResolver, IVal
         j.add("package-id", pf.packageId());
         j.add("ig-ver", pf.publishedIg.getVersion());
       }
+      if (settings.getMode() == PublisherUtils.IGBuildMode.PUBLICATION) {
+        // Lever C (-reuse-build): record the final publication path this output was rendered for, so
+        // -go-publish -reuse-build can verify a pre-built output is publication-ready before adopting it.
+        j.add("publication-url", targetUrl());
+      }
       j.add("date", new SimpleDateFormat("EEE, dd MMM, yyyy HH:mm:ss Z", new Locale("en", "US")).format(pf.getExecTime().getTime()));
       j.add("dateISO8601", new DateTimeType(pf.getExecTime()).asStringValue());
       if (val != null) {

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/PublicationProcess.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/PublicationProcess.java
@@ -605,19 +605,45 @@ public class PublicationProcess {
 
       // create a temporary copy and build in that:
       File temp = cloneToTemp(tempDir, fSource, npm.name()+"#"+npm.version());
-      File tempM = null; 
+      File tempM = null;
       System.out.println("Build IG at "+fSource.getAbsolutePath()+": final copy suitable for publication (in "+temp.getAbsolutePath()+")");
       String[] baseParams = new String[] {"-publish", pathVer, "-no-exit" };
       String tx = getNamedParam(args, "-tx");
       if (tx != null) {
         baseParams = Utilities.concatStringArray(baseParams, new String[] {"-tx", tx});
       }
-      runBuild(qa, temp.getAbsolutePath(), Utilities.concatStringArray(baseParams, new String[] {"-ig", temp.getAbsolutePath(), "-resetTx"}));
+
+      // Lever C (-reuse-build, opt-in, off by default): the publication pipeline normally renders the IG
+      // twice (an -ig step, then this -publish render). When -reuse-build is passed AND the pre-built
+      // output that was cloned into temp/output was itself rendered in PUBLICATION mode for this exact
+      // pathVer (verified via the qa.json "publication-url" marker), adopt it instead of re-rendering.
+      // Any mismatch falls back to the full render, so this can never publish stale/non-publication output.
+      boolean reuseBuild = hasParam(args, "-reuse-build");
+      boolean reused = false;
+      if (reuseBuild) {
+        if (isReusablePublicationBuild(temp, pathVer)) {
+          System.out.println("[-reuse-build] Adopting pre-built publication output at "+Utilities.path(temp.getAbsolutePath(), "output")+" (skipping the internal -publish render for "+pathVer+")");
+          reused = true;
+        } else {
+          System.out.println("[-reuse-build] Pre-built output is not a verified PUBLICATION build for "+pathVer+" - performing a full -publish render");
+        }
+      }
+      if (!reused) {
+        runBuild(qa, temp.getAbsolutePath(), Utilities.concatStringArray(baseParams, new String[] {"-ig", temp.getAbsolutePath(), "-resetTx"}));
+      }
 
       if (mode != PublicationProcessMode.WORKING) {
         tempM = cloneToTemp(tempDir, temp, npm.name()+"#"+npm.version()+"-milestone");
-        System.out.println("Build IG at "+fSource.getAbsolutePath()+": final copy suitable for publication (in "+tempM.getAbsolutePath()+") (milestone build)");        
-        runBuild(qa, tempM.getAbsolutePath(), Utilities.concatStringArray(baseParams, new String[] {"-ig", tempM.getAbsolutePath(), "-milestone"}));
+        // The only render-time difference between a -publish and a -milestone build is related-IG link
+        // targets (canonical vs web-location). When the IG declares no related IGs, the milestone render
+        // is byte-identical to the (reused) -publish render, so we can reuse it too; otherwise re-render.
+        boolean reuseMilestone = reused && !hasRelatedIGs(prSrc);
+        if (reuseMilestone) {
+          System.out.println("[-reuse-build] No related IGs declared - reusing the publication output for the milestone build too (in "+tempM.getAbsolutePath()+")");
+        } else {
+          System.out.println("Build IG at "+fSource.getAbsolutePath()+": final copy suitable for publication (in "+tempM.getAbsolutePath()+") (milestone build)");
+          runBuild(qa, tempM.getAbsolutePath(), Utilities.concatStringArray(baseParams, new String[] {"-ig", tempM.getAbsolutePath(), "-milestone"}));
+        }
       }
 
       // 2. make a copy of what we built
@@ -1247,6 +1273,41 @@ public class PublicationProcess {
       }
     }
     return null;
+  }
+
+  private static boolean hasParam(String[] args, String param) {
+    for (String a : args) {
+      if (param.equals(a)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Lever C (-reuse-build): true when the output cloned into temp/output was rendered in PUBLICATION
+   * mode for exactly this pathVer. The publisher records that path in qa.json as "publication-url" only
+   * when run with -publish; a normal -ig (MANUAL) build has no such marker, so this returns false and
+   * the caller falls back to a full render.
+   */
+  private boolean isReusablePublicationBuild(File temp, String pathVer) {
+    try {
+      File fQA = new File(Utilities.path(temp.getAbsolutePath(), "output", "qa.json"));
+      if (!fQA.exists()) {
+        return false;
+      }
+      JsonObject tqa = JsonParser.parseObject(loadFile("Reuse-build QA file", fQA.getAbsolutePath()));
+      String pubUrl = tqa.asString("publication-url");
+      return pubUrl != null && pubUrl.equals(pathVer);
+    } catch (Exception e) {
+      System.out.println("[-reuse-build] Could not verify pre-built output ("+e.getMessage()+") - performing a full render");
+      return false;
+    }
+  }
+
+  private boolean hasRelatedIGs(JsonObject prSrc) {
+    JsonObject related = prSrc.getJsonObject("related");
+    return related != null && !related.getProperties().isEmpty();
   }
 
 


### PR DESCRIPTION
## Problem

When a publication pipeline runs an `-ig` build and then `-go-publish`, the IG is rendered **twice** —
the pipeline's `-ig` step, then go-publish's own internal `-publish` render (and a **third** `-milestone`
render for milestone releases). Each render is many minutes, so the redundant one dominates publish time.

The re-render isn't gratuitous: a plain `-ig` build renders in **MANUAL** mode, so its output bakes
`file://` self-paths and skips the previous-version comparison pages — it isn't publishable. go-publish
re-renders in **PUBLICATION** mode purely to bake the final canonical path (`pathVer`). But if the
pipeline's `-ig` step is itself run in publication mode (`-ig … -publish <path>`), its output is already
exactly what go-publish would produce — so the re-render is pure duplication.

## Change (opt-in, off by default)

A new `-go-publish -reuse-build` flag. When set, go-publish **adopts the pre-built `source/output/`**
instead of re-rendering — *only* after verifying it is a PUBLICATION build for the exact `pathVer`.

- `Publisher` writes a `"publication-url"` marker into `qa.json` **only** in PUBLICATION mode
  (additive; absent and inert for every other build).
- `PublicationProcess.doPublish` reuses the output **iff** `qa.publication-url == pathVer`. Any mismatch
  (no marker, MANUAL build, stale path, unreadable qa.json) **falls back to the existing full render** —
  it can never publish stale/non-publication output.
- For IGs that declare **no related IGs**, the `-milestone` render is reused too — `isMilestoneBuild()`
  only changes related-IG link targets, so with none declared the milestone render is byte-identical to
  the `-publish` render. IGs with related IGs keep the dedicated `-milestone` render.

**Default behaviour is unchanged** — without `-reuse-build`, the code path is identical to today.
And it's **forward/backward compatible**: `-publish <path>` is existing functionality, so a pipeline can
adopt publication-mode `-ig` against an older jar that ignores `-reuse-build` and simply re-renders as
before; the speedup switches on once a jar with the flag is deployed. No flag-day.

## Why it's a good change

- Cuts working publishes from **2 → 1** render and (related-IG-free) milestones from **3 → 1**.
- Opt-in + verified + fail-closed: zero risk to existing go-publish users.
- General — benefits any multi-version IG with a render-then-publish pipeline, not a one-off.

## Verification

End-to-end in the `hl7fhir/ig-publisher-base` container against a real IG (HL7 AU Base, ~5,600 output
files):

1. **Marker** — a PUBLICATION render writes `"publication-url": "<path>"` to `qa.json`; the render also
   produced the comparison pages and `665,871 links, 0 broken`.
2. **Reuse fires, render skipped** — go-publish logged `[-reuse-build] Adopting pre-built publication
   output … (skipping the internal -publish render …)` and went straight to the post-render steps;
   publish completed normally (version folder + regenerated history/feeds/registry/publish-box).
3. **Fallback** — against a MANUAL `-ig` output (no marker), `-reuse-build` logs the mismatch and
   performs the full render.
4. **Gold-standard A/B byte-diff** — published the same source with vs without `-reuse-build` and diffed
   the two `fhir/<version>/` folders:
   - **same 5,616-file set**; **0 substantive content differences**; **0 `file://` leaks**; identical
     canonical paths.
   - The files that differ do so only by **per-render nondeterminism** present between *any* two renders:
     build timestamps, randomly-generated element/anchor IDs (incl. comparison-table `filterTree` ids),
     and HashMap/terminology-expansion ordering. (Expected — reuse copies bytes; it cannot introduce
     content.)
   - **Wall-clock (go-publish phase): 725 s → 100 s (~86% faster)** — the delta is exactly the render
     reuse skips.

## When to enable / trade-off

Low-risk by construction — it's opt-in and **fail-closed**: any marker mismatch falls back to the full
render, so it can never publish stale or non-publication output. The only requirement is that the
pipeline render its `-ig` step in publication mode (`-ig … -publish <path>`); if it doesn't, `-reuse-build`
simply re-renders as today (no speedup, no harm).

There's no real correctness trade-off — reuse copies the exact bytes the internal `-publish` render
would produce (verified: 0 substantive content diffs). The only reason to leave it off is if you
deliberately want a second, independent render from source as a belt-and-suspenders check, or your
pipeline can't render `-ig` in publication mode. IGs **with** related IGs keep their dedicated
`-milestone` render automatically (reuse applies to the `-publish` step) — not a user choice.

## Scope / notes

- Independent of any other open PR; touches only `Publisher.recordOutcome` (the additive marker) and
  `PublicationProcess.doPublish` (+ small private helpers).
- Pipelines opt in by (a) rendering their `-ig` step as `-ig … -publish <path>` and (b) passing
  `-reuse-build` to `-go-publish`.
