### PR TITLE
Add opt-in dynamic-source-viewers parameter (client-side json/xml/ttl source rendering)

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherFields.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherFields.java
@@ -237,6 +237,9 @@ public class PublisherFields {
     CSVWriter allProfilesCsv;
     StructureDefinitionSpreadsheetGenerator allProfilesXlsx;
     boolean produceJekyllData;
+    // A3: emit the json/xml/ttl "view source" pages as a small client-side shell that fetches the raw
+    // file and highlights it (instead of baking the full highlighted source into every page). Opt-in.
+    boolean dynamicSourceViewers;
     boolean noUsageCheck;
     boolean hasTranslations;
     String defaultTranslationLang;

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java
@@ -962,6 +962,48 @@ public class PublisherGenerator extends PublisherBase implements BaseRenderer.Re
   }
 
 
+  // A3: shell for a "view source" page that fetches the raw resource file (same directory) and
+  // highlights it client-side with Prism (already loaded on the page), instead of baking the full
+  // highlighted+linked source into every page. Trade-off: the in-source FHIR reference hyperlinks
+  // (which the server-side renderer adds) are not present in this client-side view; syntax
+  // highlighting and the raw content are. Opt-in via the 'dynamic-source-viewers' parameter.
+  // The JS lives in a separate file (dynamic-source.js) referenced relatively, because HTMLInspector
+  // disallows inline <script> in generated pages.
+  private static final String DYNAMIC_SOURCE_JS_FILE = "dynamic-source.js";
+  private boolean dynamicSourceJsWritten = false;
+
+  private String dynamicSourceShell(FetchedResource r, String ext, String prismLang) throws IOException {
+    ensureDynamicSourceJs();
+    String raw = Utilities.escapeXml(r.fhirType()+"-"+r.getId()+"."+ext);
+    return "<pre class=\"fhir-source-dyn\" data-src=\""+raw+"\" style=\"white-space: pre; text-wrap: nowrap; width: auto;\">"
+        + "<code class=\"language-"+prismLang+"\">Loading source…</code></pre>"
+        + "<script src=\""+DYNAMIC_SOURCE_JS_FILE+"\"> </script>";
+  }
+
+  private void ensureDynamicSourceJs() throws IOException {
+    if (dynamicSourceJsWritten) {
+      return;
+    }
+    dynamicSourceJsWritten = true;
+    String path = Utilities.path(pf.tempDir, DYNAMIC_SOURCE_JS_FILE);
+    FileUtilities.stringToFile(DYNAMIC_SOURCE_JS, path);
+    pf.otherFilesRun.add(path); // so it is treated as expected output and not cleaned up
+  }
+
+  // Self-contained, idempotent. Fetches each pre.fhir-source-dyn's data-src and renders it; highlights
+  // with Prism if available, otherwise shows the raw text.
+  private static final String DYNAMIC_SOURCE_JS =
+      "(function(){function go(){var els=document.querySelectorAll('pre.fhir-source-dyn[data-src]');"
+    + "Array.prototype.forEach.call(els,function(pre){"
+    + "if(pre.getAttribute('data-done'))return;pre.setAttribute('data-done','1');"
+    + "var code=pre.querySelector('code');var src=pre.getAttribute('data-src');"
+    + "fetch(src,{cache:'no-cache'}).then(function(r){if(!r.ok)throw 0;return r.text();}).then(function(t){"
+    + "code.textContent=t;if(window.Prism&&Prism.highlightElement){try{Prism.highlightElement(code);}catch(e){}}"
+    + "}).catch(function(){code.textContent='(unable to load '+src+')';});"
+    + "});}"
+    + "if(document.readyState!=='loading'){go();}else{document.addEventListener('DOMContentLoaded',go);}"
+    + "})();";
+
   private void saveFileOutputs(FetchedFile f, String lang) throws IOException, FHIRException {
     long start = System.currentTimeMillis();
     if (f.getResources().size() == 1) {
@@ -1093,41 +1135,59 @@ public class PublisherGenerator extends PublisherBase implements BaseRenderer.Re
 
     if (wantGen(r, "xml-html")) {
       long start = System.currentTimeMillis();
-      XmlXHtmlRenderer x = new XmlXHtmlRenderer();
-      x.setPrism(size < PRISM_SIZE_LIMIT);
-      xp.setLinkResolver(this.pf.igpkp);
-      xp.setShowDecorations(false);
-      if (suppressId(f, r)) {
-        xp.setIdPolicy(ParserBase.IdRenderingPolicy.NotRoot);
+      String content;
+      if (pf.dynamicSourceViewers) {
+        content = dynamicSourceShell(r, "xml", "markup");
+      } else {
+        XmlXHtmlRenderer x = new XmlXHtmlRenderer();
+        x.setPrism(size < PRISM_SIZE_LIMIT);
+        xp.setLinkResolver(this.pf.igpkp);
+        xp.setShowDecorations(false);
+        if (suppressId(f, r)) {
+          xp.setIdPolicy(ParserBase.IdRenderingPolicy.NotRoot);
+        }
+        xp.compose(e, x);
+        content = x.toString();
       }
-      xp.compose(e, x);
-      fragment(r.fhirType()+"-"+r.getId()+"-xml-html", x.toString(), f.getOutputNames(), r, vars, "xml", start, "xml-html", "Resource", lang);
+      fragment(r.fhirType()+"-"+r.getId()+"-xml-html", content, f.getOutputNames(), r, vars, "xml", start, "xml-html", "Resource", lang);
     }
     if (wantGen(r, "json-html")) {
       long start = System.currentTimeMillis();
-      JsonXhtmlRenderer j = new JsonXhtmlRenderer();
-      j.setPrism(size < PRISM_SIZE_LIMIT);
-      org.hl7.fhir.r5.elementmodel.JsonParser jp = new org.hl7.fhir.r5.elementmodel.JsonParser(this.pf.context);
-      jp.setLinkResolver(this.pf.igpkp);
-      jp.setAllowComments(true);
-      if (suppressId(f, r)) {
-        jp.setIdPolicy(ParserBase.IdRenderingPolicy.NotRoot);
+      String content;
+      if (pf.dynamicSourceViewers) {
+        content = dynamicSourceShell(r, "json", "json");
+      } else {
+        JsonXhtmlRenderer j = new JsonXhtmlRenderer();
+        j.setPrism(size < PRISM_SIZE_LIMIT);
+        org.hl7.fhir.r5.elementmodel.JsonParser jp = new org.hl7.fhir.r5.elementmodel.JsonParser(this.pf.context);
+        jp.setLinkResolver(this.pf.igpkp);
+        jp.setAllowComments(true);
+        if (suppressId(f, r)) {
+          jp.setIdPolicy(ParserBase.IdRenderingPolicy.NotRoot);
+        }
+        jp.compose(e, j);
+        content = j.toString();
       }
-      jp.compose(e, j);
-      fragment(r.fhirType()+"-"+r.getId()+"-json-html", j.toString(), f.getOutputNames(), r, vars, "json", start, "json-html", "Resource", lang);
+      fragment(r.fhirType()+"-"+r.getId()+"-json-html", content, f.getOutputNames(), r, vars, "json", start, "json-html", "Resource", lang);
     }
 
     if (wantGen(r, "ttl-html")) {
       long start = System.currentTimeMillis();
-      org.hl7.fhir.r5.elementmodel.TurtleParser ttl = new org.hl7.fhir.r5.elementmodel.TurtleParser(this.pf.context);
-      ttl.setLinkResolver(this.pf.igpkp);
-      Turtle rdf = new Turtle();
-      if (suppressId(f, r)) {
-        ttl.setIdPolicy(ParserBase.IdRenderingPolicy.NotRoot);
+      String content;
+      if (pf.dynamicSourceViewers) {
+        content = dynamicSourceShell(r, "ttl", "turtle");
+      } else {
+        org.hl7.fhir.r5.elementmodel.TurtleParser ttl = new org.hl7.fhir.r5.elementmodel.TurtleParser(this.pf.context);
+        ttl.setLinkResolver(this.pf.igpkp);
+        Turtle rdf = new Turtle();
+        if (suppressId(f, r)) {
+          ttl.setIdPolicy(ParserBase.IdRenderingPolicy.NotRoot);
+        }
+        ttl.setStyle(IParser.OutputStyle.PRETTY);
+        ttl.compose(e, rdf, "");
+        content = rdf.asHtml(size < PRISM_SIZE_LIMIT);
       }
-      ttl.setStyle(IParser.OutputStyle.PRETTY);
-      ttl.compose(e, rdf, "");
-      fragment(r.fhirType()+"-"+r.getId()+"-ttl-html", rdf.asHtml(size < PRISM_SIZE_LIMIT), f.getOutputNames(), r, vars, "ttl", start, "ttl-html", "Resource", lang);
+      fragment(r.fhirType()+"-"+r.getId()+"-ttl-html", content, f.getOutputNames(), r, vars, "ttl", start, "ttl-html", "Resource", lang);
     }
 
     generateHtml(f, r, res, langElement, vars, lrc, lang);

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherIGLoader.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherIGLoader.java
@@ -661,6 +661,9 @@ public class PublisherIGLoader extends PublisherBase {
         case "produce-jekyll-data":
           pf.produceJekyllData = "true".equals(p.getValue());
           break;
+        case "dynamic-source-viewers":
+          pf.dynamicSourceViewers = "true".equals(p.getValue());
+          break;
         case "page-factory":
           dir = Utilities.path(pf.rootDir, "temp", "factory-pages", "factory"+ pf.pageFactories.size());
           FileUtilities.createDirectory(dir);


### PR DESCRIPTION
## Summary

Adds an **opt-in** IG parameter, `dynamic-source-viewers`, that renders the JSON/XML/Turtle
"view source" pages **client-side from the raw resource file** instead of baking a full
syntax-highlighted copy of the source into every page.

**Off by default** — no IG that doesn't set the parameter is affected, so this changes no existing
output.

## Motivation

For every resource the publisher emits `X.json.html`, `X.xml.html`, `X.ttl.html`. Each is a full page
whose body is the resource serialized, syntax-highlighted, and wrapped in page chrome — i.e. the same
data as the raw `X.json`/`X.xml`/`X.ttl` (which are also published), just highlighted. For large IGs
this is the single biggest per-resource cost.

Measured on the AU Base IG (v6.0.0, ~270 MB uncompressed): the viewer pages are **73.2 MB across 822
files (~27% of the whole version)**; large resources reach ~90 KB per viewer page. Cutting them ~86%
(below) takes the viewer pages from **~27% → ~5% of the version**, shrinking the **whole version by
~23%** (~63 MB off ~270 MB).

## What it does

When `dynamic-source-viewers=true`, each viewer page's body becomes:

```html
<pre class="fhir-source-dyn" data-src="StructureDefinition-foo.json">
  <code class="language-json">Loading source…</code></pre>
<script src="dynamic-source.js"> </script>
```

`dynamic-source.js` (one ~0.7 KB file per output, written once and registered in `otherFilesRun`)
fetches the raw file from the same directory and highlights it with **Prism, which is already loaded
on the page**. The existing tab links are unchanged (`X.json.html` still exists), so no template
change is required.

### Why a `.js` file rather than inline script
`HTMLInspector` (correctly) rejects inline `<script>` in generated pages (FATAL on the ci-build), so
the JS is shipped as a **relative** `dynamic-source.js` (which the inspector permits) and registered as
expected output. Verified: 0 inline scripts, 0 broken links.

## Changes
- `PublisherFields` — `dynamicSourceViewers` flag.
- `PublisherIGLoader` — reads the `dynamic-source-viewers` parameter.
- `PublisherGenerator.saveDirectResourceOutputs` — emits the shell (`dynamicSourceShell`) instead of
  the baked source for the `xml-html`/`json-html`/`ttl-html` fragments; `ensureDynamicSourceJs` writes
  the JS file once.

~91 lines across 3 files. No change to default behaviour.

## Validation

A controlled `-ig` build of AU Base in the `hl7fhir/ig-publisher-base` container, with the parameter
on, compared to the published v6.0.0 (same version, baked):

| viewer pages | baked (published 6.0.0) | with this change | reduction |
|---|---|---|---|
| `.json.html` + `.xml.html` + `.ttl.html` | 822 files, **73.2 MB** | 840 files, **~10.2 MB** | **~86% (~63 MB/version)** |

- Each viewer page drops from up to ~90 KB to a flat ~11.8 KB (the remainder is shared page chrome).
- **Whole-version impact:** viewer pages go from **~27% → ~5%** of the version, taking the version from
  **~270 MB → ~207 MB (~23% smaller)**. Across ~27 published au-base versions that is ~1.5 GB removed
  bucket-wide.
- Build clean: **0 broken links, 0 inline scripts**; `dynamic-source.js` emitted and referenced by the
  viewer pages.

### Rendered-behaviour test (executed, not just static)

The deployed preview viewer page was loaded in **headless Chrome** and the post-JS DOM inspected — to
confirm the source actually renders (not just that the files exist):

- `Loading source…` placeholder is replaced by the real resource (`{ "resourceType": "ValueSet", … }`,
  3,524 chars — matches the 3,570-byte raw file); no `(unable to load …)`.
- **Prism highlighting ran**: 207 `token` spans in the rendered `<code>`. No console/page errors.
- The documented trade-off is confirmed by measurement on the same resource: the **baked** viewer
  carries **46 in-source `<a href>` links** (45 of them element-name → FHIR-R4-spec definitions, 1
  external); the **dynamic** viewer has **0**. So content + syntax highlighting are intact; only the
  element-name → spec convenience links are dropped.

### See it live — deployed preview vs. published baked

Same resource, same version, side by side:

| | URL | source rendering |
|---|---|---|
| **Dynamic** (this change, deployed preview) | [`…/pr-1074/…/ValueSet-au-v3-ActEncounterCode-extended.json.html`](https://hl7au.github.io/au-fhir-base/previews/pr-1074/working/fhir/6.0.1-ci-build/ValueSet-au-v3-ActEncounterCode-extended.json.html) | client-side fetch + Prism (no in-source links) |
| **Baked** (current published AU Base) | [`hl7.org.au/fhir/ValueSet-au-v3-ActEncounterCode-extended.json.html`](https://hl7.org.au/fhir/ValueSet-au-v3-ActEncounterCode-extended.json.html) | server-baked highlighted source (with in-source links) |

(The preview was built with a jar carrying this change; the dynamic viewer renders identically on the
github.io sub-path and would at the canonical root — see "When to enable" for the path/origin check.)

## When to enable — and the trade-off (why it's opt-in)

The real cost is **the in-source hyperlinks the baked viewer carries are lost** in the client-side
view. The server-side renderer turns the source into a linked document — most pervasively, **every
element name links to its definition in the base FHIR spec**, plus references/canonical URLs/profile
URLs become links to their target pages. The raw file has none of these, so the client-side highlight
shows colourised text only.

This is not theoretical — measured on AU Base (60 sampled `.json.html` pages): **every page** had
in-source links, **~58 per page on average** (up to ~198 on a StructureDefinition); ~97% are
element-name → FHIR-R4-definition links and ~3% are internal profile/reference links. So enabling this
is a deliberate trade of **"linked, explorable source"** for **a ~86% smaller per-version footprint**.

Also note the client-side viewer needs **JS + a same-dir fetch** of the raw file, so no-JS / offline /
downloaded copies show `Loading source…` (and `(unable to load …)` if the fetch fails) rather than the
source — whereas the baked page renders offline.

**Works at any deployment path or origin (verified against a live published IG).** The shell fetches a
**relative** `data-src` (e.g. `ValueSet-foo.json`, the same directory as the page) and highlights with
the Prism that is **already loaded on every page** — no absolute paths and no cross-origin assumptions.
It therefore renders identically on a local build, a CI preview served from a deep sub-path, and a
published IG at its canonical root. Confirmed end-to-end against the live published **AU Base
(`https://hl7.org.au/fhir`)**: the raw `…json` resolves same-origin (HTTP 200), `prism.js`/`prism.css`
are present on the viewer page, and the source highlights correctly — i.e. a preview built with this
jar behaves the same once promoted to the canonical site.

**Enable it** when per-version size/storage is the priority and the linked-source feature isn't
important to your audience. **Keep it off** (the default) when the explorable, linked source matters, or
for offline / no-JS / downloaded-copy consumption.

### Requirements
- **Requires the raw `json`/`xml`/`ttl` formats to be generated** (they normally are); if a format's
  raw file isn't published, that viewer shows a "source unavailable" message rather than 404-ing the page.
- **Companion registration:** the `dynamic-source-viewers` code must be added to the `ig-parameters`
  CodeSystem/ValueSet in `hl7.fhir.uv.tools` (as for any new parameter) — otherwise IGs that opt in get
  "code not in value set" validation messages. That registration PR is open:
  **FHIR/fhir-tools-ig#13** (a pure-additive CodeSystem concept). This PR itself introduces no new QA
  errors.

## Future work — retaining the in-source links (optional phase 2)

The lost in-source links are not intrinsic to client-side rendering — they're regular enough to restore
without re-baking the source HTML. Each baked link is an **absolute URL into the base FHIR spec, keyed
purely by element path + defining type** (e.g. `…/R4/resource.html#ValueSet.id`,
`…/R4/datatypes.html#Meta.profile`), so the target is a deterministic function of the element path, not
of the instance data — and ~97% of links are this kind. Two ways to bring them back as a layered,
still-opt-in enhancement (this PR stays the simple baseline):

- **Option A — per-resource link sidecar (most faithful).** The renderer already computes these links;
  instead of baking them into HTML, emit a tiny sidecar per resource (the linked tokens in document
  order: element path, or char-range + href). `dynamic-source.js` then highlights and wraps each token
  from the sidecar. For JSON this is clean because Prism already isolates property keys as
  `.token.property` spans in document order, so links land on token boundaries (no offset math); XML/TTL
  element-name tokens are analogous. The sidecar is a few KB of mostly-repetitive paths vs the ~78 KB of
  baked HTML, so most of the ~86% win is kept *and* the links return.

- **Option B — one shared element→URL map + client path-tracking.** Because the map is FHIR-version
  global (not IG-specific), ship a single static `element-links.json` for the whole site, fetched once
  and cached, and reconstruct each element's path on the client while walking the source. Zero
  per-resource artifacts, but reconstructing paths from *raw* JSON needs type resolution for nested/typed
  elements (e.g. knowing `meta` is a `Meta` to reach `Meta.profile`) — essentially part of the element
  model in JS, or heuristics that risk *wrong* links.

A **hybrid** is the sweet spot: a tiny per-resource ordered **path** list (Option A's sidecar, paths
only — no hrefs) plus Option B's shared version-global path→URL map, so the client only zips
tokens↔paths↔URLs and never re-derives semantics. This could be a second value of the parameter
(e.g. `dynamic-source-viewers: links` vs the lean default) so IGs pick size-vs-links. Happy to follow up
with a prototype + measurement if there's interest.

## Notes
- Independent change; touches only the resource-render path. Tested against AU Base but the mechanism
  is IG-agnostic.
- A larger win (also dropping the per-page chrome via a shared viewer shell / inline tabs) is possible
  but would need template changes; this PR deliberately keeps the per-resource page + tab links intact.
- Naming/parameter conventions, the JS asset location, and the Prism language mapping
  (`json`/`markup`/`turtle`) are all open to your preference — glad to adjust.

