### PR TITLE
Resolve canonicals whose URL last segment differs from the resource id (cross-namespace canonicals)

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/IGReleaseRedirectionBuilder.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/IGReleaseRedirectionBuilder.java
@@ -91,31 +91,24 @@ public class IGReleaseRedirectionBuilder {
       "    \r\n"+
       "You should not be seeing this page. If you do, PHP has failed badly.\r\n";
 
-  private static final String HTML_TEMPLATE = "<?php\r\n"+
-      "function Redirect($url)\r\n"+
-      "{\r\n"+
-      "  header('Location: ' . $url, true, 302);\r\n"+
-      "  exit();\r\n"+
-      "}\r\n"+
-      "\r\n"+
-      "$accept = $_SERVER['HTTP_ACCEPT'];\r\n"+
-      "if (strpos($accept, 'application/json+fhir') !== false)\r\n"+
-      "  Redirect('{{literal}}.json2');\r\n"+
-      "elseif (strpos($accept, 'application/fhir+json') !== false)\r\n"+
-      "  Redirect('{{literal}}.json1');\r\n"+
-      "elseif (strpos($accept, 'json') !== false)\r\n"+
-      "  Redirect('{{literal}}.json');\r\n"+
-      "elseif (strpos($accept, 'application/xml+fhir') !== false)\r\n"+
-      "  Redirect('{{literal}}.xml2');\r\n"+
-      "elseif (strpos($accept, 'application/fhir+xml') !== false)\r\n"+
-      "  Redirect('{{literal}}.xml1');\r\n"+
-      "elseif (strpos($accept, 'html') !== false)\r\n"+
-      "  Redirect('{{html}}');\r\n"+
-      "else \r\n"+
-      "  Redirect('{{literal}}.xml');\r\n"+
-      "?>\r\n"+
-      "    \r\n"+
-      "You should not be seeing this page. If you do, PHP has failed badly.\r\n";
+  // Static HTML redirect for cloud / static hosting (e.g. S3, GitHub Pages, Netlify)
+  // that cannot execute server-side scripts. Content negotiation on the Accept header
+  // is not possible without a server runtime, so this redirects browsers to the human
+  // readable page and links the JSON/XML representations for machine clients.
+  private static final String HTML_TEMPLATE = "<!DOCTYPE html>\r\n"+
+      "<html lang=\"en\">\r\n"+
+      "<head>\r\n"+
+      "  <meta charset=\"utf-8\"/>\r\n"+
+      "  <meta http-equiv=\"refresh\" content=\"0; url={{html}}\"/>\r\n"+
+      "  <link rel=\"canonical\" href=\"{{html}}\"/>\r\n"+
+      "  <title>Redirecting&hellip;</title>\r\n"+
+      "  <script type=\"text/javascript\">window.location.replace(\"{{html}}\");</script>\r\n"+
+      "</head>\r\n"+
+      "<body>\r\n"+
+      "  <p>This FHIR resource is published at <a href=\"{{html}}\">{{html}}</a>. Redirecting now&hellip;</p>\r\n"+
+      "  <p>Machine-readable formats: <a href=\"{{literal}}.json\">JSON</a> &middot; <a href=\"{{literal}}.xml\">XML</a></p>\r\n"+
+      "</body>\r\n"+
+      "</html>\r\n";
   
   private static final String WC_START_ROOT = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" + 
       "<configuration>\n" + 

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/IGReleaseRedirectionBuilder.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/IGReleaseRedirectionBuilder.java
@@ -174,7 +174,7 @@ public class IGReleaseRedirectionBuilder {
     }
   }
   
-  public void buildCloudRedirections() throws IOException {    
+  public void buildCloudRedirections() throws IOException {
     Map<String, String> map = createMap(false);
     if (map != null) {
       for (String s : map.keySet()) {
@@ -182,11 +182,49 @@ public class IGReleaseRedirectionBuilder {
           String path = Utilities.path(folder, s, "index.html");
           String p = s.replace("/", "-");
           String litPath = Utilities.path(folder, p);
-          if (new File(litPath+".xml").exists() && new File(litPath+".json").exists()) 
+          if (new File(litPath+".xml").exists() && new File(litPath+".json").exists())
             createHtmlRedirect(path, map.get(s), Utilities.pathURL(vpath, p));
+        } else if (s.contains("://")) {
+          // The canonical is hosted in a different namespace than the IG (e.g. an AU
+          // external-terminology extension: resource id 'au-x' but canonical '.../ValueSet/x').
+          // The resource renders as <Type>-<id>.html, but canonical resolution targets
+          // <Type>-<tail>.html (tail = the canonical's last segment), so the published canonical
+          // 404s. Emit a flat alias <Type>-<tail>.html that redirects to the real rendered file.
+          createCanonicalUrlAlias(s, map.get(s));
         }
       }
     }
+  }
+
+  /**
+   * Emit a flat redirect alias for a canonical whose last path segment differs from the rendered
+   * resource id. spec.internals already records the canonical -> rendered-file mapping; this
+   * materialises it as <Type>-<tail>.html -> <Type>-<id>.html so dereferencing the published
+   * canonical resolves. No-op when the canonical tail already equals the id (the common case).
+   */
+  private void createCanonicalUrlAlias(String canonicalUrl, String targetUrl) throws IOException {
+    String[] seg = canonicalUrl.split("/");
+    if (seg.length < 2 || targetUrl == null) {
+      return;
+    }
+    String aliasName = seg[seg.length - 2] + "-" + seg[seg.length - 1];        // <Type>-<tail>
+    String targetFile = targetUrl.substring(targetUrl.lastIndexOf('/') + 1);   // <Type>-<id>.html
+    if ((aliasName + ".html").equals(targetFile)) {
+      return; // canonical tail already matches the rendered id - nothing to alias
+    }
+    if (!new File(Utilities.path(folder, targetFile)).exists()) {
+      return; // only alias when the real rendered page is present in this folder
+    }
+    String aliasPath = Utilities.path(folder, aliasName + ".html");
+    if (new File(aliasPath).exists() && !isRedirectStub(aliasPath)) {
+      return; // never overwrite a real rendered page that happens to share the alias name
+    }
+    String litSrc = targetUrl.endsWith(".html") ? targetUrl.substring(0, targetUrl.length() - 5) : targetUrl;
+    createHtmlRedirect(aliasPath, targetUrl, litSrc);
+  }
+
+  private boolean isRedirectStub(String path) throws IOException {
+    return FileUtilities.fileToString(path).contains("window.location.replace");
   }
   
   public void buildNewAspRedirections(boolean isCore, boolean isCoreRoot) throws IOException {

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/PublicationProcess.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/web/PublicationProcess.java
@@ -1059,6 +1059,8 @@ public class PublicationProcess {
       IGReleaseRedirectionBuilder rb = new IGReleaseRedirectionBuilder(destVer, pl.canonical(), plVer.path(), rootFolder);
       if (serverType == ServerType.APACHE) {
         rb.buildApacheRedirections();
+      } else if (serverType == ServerType.CLOUD) {
+        rb.buildCloudRedirections();
       } else if (serverType == ServerType.ASP2) {
         rb.buildNewAspRedirections(false, false);
       } else if (serverType == ServerType.ASP1) {


### PR DESCRIPTION
## Problem

A FHIR resource can legitimately have a **canonical URL whose last path segment differs from its `id`** (and therefore from its rendered filename). When it does, the published canonical does not resolve — it 404s and falls through to the IG landing/history page.

Real-world case: **AU Base external-terminology extensions**. By convention these are authored as:
- `id` = `au-v3-ActEncounterCode-extended` → rendered file `ValueSet-au-v3-ActEncounterCode-extended.html`
- `url` (canonical) = `http://terminology.hl7.org.au/ValueSet/v3-ActEncounterCode-extended` (no `au-`)

FHIR does not require `id` and `url` to match, and this difference is intentional (the AU terminology authors confirmed the convention: `id` gets the `au-` prefix; the canonical uses `<hl7-au-namespace>/<external-id>-extended`). 13 resources in AU Base 6.x follow it.

Dereferencing the canonical resolves to `…/ValueSet-v3-ActEncounterCode-extended.html`, but the publisher only ever wrote `…/ValueSet-**au-**v3-ActEncounterCode-extended.html`, so → 404.

## Root cause

`spec.internals` **already records the canonical → rendered-file mapping**, e.g.:

```
"http://terminology.hl7.org.au/ValueSet/v3-ActEncounterCode-extended" : "ValueSet-au-v3-ActEncounterCode-extended.html"
```

But `IGReleaseRedirectionBuilder.buildCloudRedirections()` only emits a stub when the path key is IG-canonical-relative; cross-namespace canonicals come through `parseSpecDetails` as full-URL keys and are dropped by the `if (!s.contains(":"))` guard. So no redirect is generated for them, and resolution targets a `<Type>-<tail>.html` file that doesn't exist.

## Fix

For a cross-namespace canonical (full-URL key) whose last segment differs from the rendered file, emit a flat alias `<Type>-<tail>.html` that redirects to the actual rendered `<Type>-<id>.html` (the mapping is already in `spec.internals`). Guards:
- no-op when `<Type>-<tail>` already equals the rendered id (the common case — no alias, no overhead);
- only when the real rendered page exists in that folder;
- never overwrites a real rendered page (only an existing redirect stub).

Generated in each published version folder, so versioned canonicals (`…|6.0.0`) resolve too.

Scope: the cloud/static redirect path (`buildCloudRedirections`). **Builds on #1327** (static-HTML redirect template + wiring `CLOUD` into `-go-publish`); the net-new change here is one method, `createCanonicalUrlAlias`.

## Testing

Built the jar and ran `-go-publish` (server type `cloud`) on AU Base 6.x, deployed the output to a GitHub Pages preview:

- **Before (prod today):** `https://hl7.org.au/fhir/ValueSet-v3-ActEncounterCode-extended.html` → *Content Not Found*.
- **After (preview):** the alias `ValueSet-v3-ActEncounterCode-extended.html` is generated, returns 200, and redirects to `ValueSet-au-v3-ActEncounterCode-extended.html` (the real resource page).
- All **13** affected canonicals now resolve (e.g. `CodeSystem-v2-0203`, `CodeSystem-v3-ActCode`, `ValueSet-jurisdiction-extended`, `ValueSet-v3-ServiceDeliveryLocationRoleType-extended`, …).
- **No regression:** a normal canonical where `id == tail` (e.g. `ValueSet-accession-number-type`) is unchanged — it renders directly, no alias emitted.

The full cross-host chain (`terminology.hl7.org.au/...` → `hl7.org.au/fhir/...` → alias) is completed by the existing edge/host rewrite; this change supplies the file that rewrite lands on.

### Live before/after

- **Fixed (preview built with this change):** https://hl7au.github.io/au-fhir-base/previews/canonical-redirects-preview/milestone/fhir/ValueSet-v3-ActEncounterCode-extended.html → resolves to the resource page.
- **Broken (production today):** https://hl7.org.au/fhir/ValueSet-v3-ActEncounterCode-extended.html → *Content Not Found*.

> ⚠️ **The aliases this PR generates are absolute** (as described above). GitHub Pages can't perform the production host rewrite and would bounce an absolute production URL off-site, so on this preview the alias files were **manually rewritten to relative purely to make the redirect clickable within Pages**. The preview demonstrates *that the alias is generated and points to the correct resource*; it does **not** reflect a change in redirect style — the PR remains absolute.

## Design note

Aliases use **absolute** redirect targets, consistent with the existing canonical/version redirect stubs (and with FHIR canonicals being absolute global identifiers). Making *preview* builds host-agnostic (so absolute links don't point at production) is a separate, broader concern (a preview/`-base` override) and is intentionally out of scope here.

## Affected resources (AU Base 6.x)

CodeSystems: `au-v2-0203`, `au-v2-0360`, `au-v2-0443`, `au-v3-ActCode`, `au-location-physical-type`, `au-location-type`.
ValueSets: `au-v2-0203-extended`, `au-v2-0360-extended`, `au-v2-0443-extended`, `au-v3-ActEncounterCode-extended`, `au-v3-ServiceDeliveryLocationRoleType-extended`, `au-jurisdiction-extended`, `au-location-physical-type-extended`.

(Genuinely-external code systems like `mims-external` → `http://www.mims.com.au/codes` are correctly left alone — their canonical points to an outside authority and shouldn't resolve to the IG.)

---
*Note: this branch is based on #1327, so the diff includes that PR's commit until it merges; the net-new commit here is the `createCanonicalUrlAlias` change.*
