### PR TITLE
Fix fhir2.base.template language StructureDefinition tree images

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/PublisherGenerator.java
@@ -1813,7 +1813,8 @@ public class PublisherGenerator extends PublisherBase implements BaseRenderer.Re
       fragmentError("StructureDefinition-"+prefixForContainer+sd.getId()+"-json-schema", "yet to be done: json schema as html", null, f.getOutputNames(), start, "json-schema", "StructureDefinition", lang);
     }
 
-    StructureDefinitionRenderer sdr = new StructureDefinitionRenderer(this.pf.context, this.pf.packageId(), checkAppendSlash(this.pf.specPath), sd, Utilities.path(this.pf.tempDir), this.pf.igpkp, this.pf.specMaps, pageTargets(), this.pf.markdownEngine, this.pf.packge, this.pf.fileList, lrc, this.pf.allInvariants, this.pf.sdMapCache, this.pf.specPath, this.pf.versionToAnnotate, this.pf.relatedIGs, this);
+    String structureDefinitionImageFolder = lang == null ? Utilities.path(this.pf.tempDir) : Utilities.path(this.pf.tempDir, lang);
+    StructureDefinitionRenderer sdr = new StructureDefinitionRenderer(this.pf.context, this.pf.packageId(), checkAppendSlash(this.pf.specPath), sd, structureDefinitionImageFolder, this.pf.igpkp, this.pf.specMaps, pageTargets(), this.pf.markdownEngine, this.pf.packge, this.pf.fileList, lrc, this.pf.allInvariants, this.pf.sdMapCache, this.pf.specPath, this.pf.versionToAnnotate, this.pf.relatedIGs, this);
     sdr.setNoXigLink(this.pf.noXigLink);
 
     if (wantGen(r, "summary")) {


### PR DESCRIPTION
Fixes #1332

## Summary

This fixes missing generated `tbl_bck*.png` tree background images for language-specific StructureDefinition pages when using `fhir2.base.template`.

## Change

When rendering StructureDefinition output for a specific language, the generated image folder now uses `temp/<lang>` instead of root `temp`. This keeps generated tree background images beside the language-specific pages that reference them with bare relative URLs.

## Verification

- Built publisher locally and tested with https://github.com/julsas/fhir-ig-test-repo/tree/broken-rendering-demo
- Verified no missing files and rendered output looks correct