### PR TITLE
Support .sql adjunct files as application/sql (#1323)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,1 @@
+* Loader: Support .sql adjunct files (application/sql) for ig-loader content attachments

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/loaders/AdjunctFileLoader.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/loaders/AdjunctFileLoader.java
@@ -233,6 +233,8 @@ public class AdjunctFileLoader {
       return "text/cql";
     } else if ("feature".equals(ext)) {
       return "text/x-gherkin";
+    } else if ("sql".equals(ext)) {
+      return "application/sql";
     } else if ("json".equals(ext)) {
       return "application/json";
     } else if ("xml".equals(ext)) {


### PR DESCRIPTION
Fixes #1323.

`AdjunctFileLoader.determineContentType()` did not recognise the `sql` extension, so a `.sql` file loaded via `content.id = ig-loader-<file>.sql` produced an `Attachment` with no `contentType`.

The SQL on FHIR SQLView and SQLQuery profiles require `content.contentType` to be present and to start with `application/sql` (their `sql-must-be-sql-expressions` invariant), so such an attachment fails validation. And because `checkReplaceable()` only fires when the attachment has no `contentType` preset, it was not possible to set `application/sql` by hand and still use the loader.

## Change

Map the `sql` extension to `application/sql`, the IANA registered media type ([RFC 6922](https://www.rfc-editor.org/rfc/rfc6922.html)). This lets SQL on FHIR Libraries reference their SQL as a plain, reviewable file rather than hand-encoded base64, mirroring the existing `.cql` workflow.
