### PR TITLE
Fixing links rendering in CodeSystem and ValueSet templates

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/CodeSystemRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/CodeSystemRenderer.java
@@ -231,7 +231,7 @@ public class CodeSystemRenderer extends CanonicalRenderer {
         if (path == null) {
           System.out.println("No path for " + vc.getUrl());
         } else {
-          b.append(" <li><a href=\"" + path + "\">" + Utilities.escapeXml(gen.getTranslated(vc.getNameElement())) + "</a></li>\r\n");
+          b.append(" <li><a href=\"" + path + "\">" + Utilities.escapeXml(gen.getTranslated(vc.getTitleElement(), vc.getNameElement())) + "</a></li>\r\n");
         }
         processed.add(path);
       }
@@ -251,7 +251,7 @@ public class CodeSystemRenderer extends CanonicalRenderer {
         if (path == null) {
           System.out.println("No path for " + vc.getUrl());
         } else {
-          b.append(" <li><a href=\"" + path + "\">" + Utilities.escapeXml(gen.getTranslated(vc.getNameElement())) + "</a></li>\r\n");
+          b.append(" <li><a href=\"" + path + "\">" + Utilities.escapeXml(gen.getTranslated(vc.getTitleElement(), vc.getNameElement())) + "</a></li>\r\n");
         }
         processed.add(path);
       }

--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/ValueSetRenderer.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/renderers/ValueSetRenderer.java
@@ -177,7 +177,7 @@ public class ValueSetRenderer extends CanonicalRenderer {
             first = false;
             b.append("<ul>\r\n");
           }
-          b.append(" <li>"+ (gen.formatPhrase(RenderingContext.VALUE_SET_INCLUDED_INTO)+" ")+"<a href=\""+vc.getWebPath()+"\">"+Utilities.escapeXml(gen.getTranslated(vc.getNameElement()))+"</a></li>\r\n");
+          b.append(" <li>"+ (gen.formatPhrase(RenderingContext.VALUE_SET_INCLUDED_INTO)+" ")+"<a href=\""+vc.getWebPath()+"\">"+Utilities.escapeXml(gen.getTranslated(vc.getTitleElement(), vc.getNameElement()))+"</a></li>\r\n");
           break;
         }
       }
@@ -189,7 +189,7 @@ public class ValueSetRenderer extends CanonicalRenderer {
             first = false;
             b.append("<ul>\r\n");
           }
-          b.append(" <li>"+ (gen.formatPhrase(RenderingContext.VALUE_SET_EXCLUDED_FROM)+" ")+"<a href=\""+vc.getWebPath()+"\">"+Utilities.escapeXml(gen.getTranslated(vc.getNameElement()))+"</a></li>\r\n");
+          b.append(" <li>"+ (gen.formatPhrase(RenderingContext.VALUE_SET_EXCLUDED_FROM)+" ")+"<a href=\""+vc.getWebPath()+"\">"+Utilities.escapeXml(gen.getTranslated(vc.getTitleElement(), vc.getNameElement()))+"</a></li>\r\n");
           break;
         }
       }


### PR DESCRIPTION
This pull request updates how ValueSet links are rendered in the UI to prefer displaying the ValueSet's title (if available) instead of just the name. The changes ensure that the title is shown when present, falling back to the name otherwise, making the rendered output more user-friendly and informative.

**Rendering improvements:**

* Updated `CodeSystemRenderer.java` so that when generating links for ValueSets, the display text now uses `gen.getTranslated(vc.getTitleElement(), vc.getNameElement())` to prefer the title over the name, in both the `addLink` methods for `ConceptSetC` and `Extension`. [[1]](diffhunk://#diff-650a5cbda2225423bcdb90b815d2289bf8b79104a29d315c00a0091707820325L234-R234) [[2]](diffhunk://#diff-650a5cbda2225423bcdb90b815d2289bf8b79104a29d315c00a0091707820325L254-R254)
* Updated `ValueSetRenderer.java` so that included and excluded ValueSet references also use the title (falling back to the name) for link text, improving clarity in the rendered output. [[1]](diffhunk://#diff-caa7b05290e3fb2c25484699f037967e0a7f4d9918a3e545a86a4bfee978a3a2L180-R180) [[2]](diffhunk://#diff-caa7b05290e3fb2c25484699f037967e0a7f4d9918a3e545a86a4bfee978a3a2L192-R192)